### PR TITLE
Add seriailize and deserialize usize

### DIFF
--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -18,7 +18,7 @@ mod hint;
 
 const ERROR_NOT_ALL_BYTES_READ: &str = "Not all bytes read";
 const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
-const ERROR_USIZE_OVERFLOW_IN_32_BIT_MACHINE: &str = "Deserialize usize overflow in 32 bit machine";
+const ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_USIZE: &str = "Overflow on machine with 32 bit usize";
 
 /// A data-structure that can be de-serialized from binary format by NBOR.
 pub trait BorshDeserialize: Sized {

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -102,7 +102,7 @@ impl BorshDeserialize for usize {
         let u = usize::try_from(u).map_err(|_| {
             Error::new(
                 ErrorKind::InvalidInput,
-                ERROR_USIZE_OVERFLOW_IN_32_BIT_MACHINE,
+                ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_USIZE,
             )
         })?;
         Ok(u)

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -50,10 +50,7 @@ impl BorshDeserialize for u8 {
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let res = buf[0];
         *buf = &buf[1..];
@@ -95,6 +92,13 @@ impl_for_integer!(u32);
 impl_for_integer!(u64);
 impl_for_integer!(u128);
 
+impl BorshDeserialize for usize {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self> {
+        let u: u64 = BorshDeserialize::deserialize(buf)?;
+        Ok(u as usize)
+    }
+}
+
 // Note NaNs have a portability issue. Specifically, signalling NaNs on MIPS are quiet NaNs on x86,
 // and vice-versa. We disallow NaNs to avoid this issue.
 macro_rules! impl_for_float {
@@ -131,10 +135,7 @@ impl BorshDeserialize for bool {
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let b = buf[0];
         *buf = &buf[1..];
@@ -157,10 +158,7 @@ where
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let flag = buf[0];
         *buf = &buf[1..];
@@ -169,10 +167,8 @@ where
         } else if flag == 1 {
             Ok(Some(T::deserialize(buf)?))
         } else {
-            let msg = format!(
-                "Invalid Option representation: {}. The first byte must be 0 or 1",
-                flag
-            );
+            let msg =
+                format!("Invalid Option representation: {}. The first byte must be 0 or 1", flag);
 
             Err(Error::new(ErrorKind::InvalidInput, msg))
         }
@@ -187,10 +183,7 @@ where
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let flag = buf[0];
         *buf = &buf[1..];
@@ -199,10 +192,8 @@ where
         } else if flag == 1 {
             Ok(Ok(T::deserialize(buf)?))
         } else {
-            let msg = format!(
-                "Invalid Result representation: {}. The first byte must be 0 or 1",
-                flag
-            );
+            let msg =
+                format!("Invalid Result representation: {}. The first byte must be 0 or 1", flag);
 
             Err(Error::new(ErrorKind::InvalidInput, msg))
         }
@@ -231,10 +222,7 @@ where
         } else if T::is_u8() && size_of::<T>() == size_of::<u8>() {
             let len = len.try_into().map_err(|_| ErrorKind::InvalidInput)?;
             if buf.len() < len {
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-                ));
+                return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
             }
             let result = buf[..len].to_vec();
             *buf = &buf[len..];
@@ -423,10 +411,7 @@ impl BorshDeserialize for std::net::Ipv4Addr {
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.len() < 4 {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let bytes: [u8; 4] = buf[..4].try_into().unwrap();
         let res = std::net::Ipv4Addr::from(bytes);
@@ -440,10 +425,7 @@ impl BorshDeserialize for std::net::Ipv6Addr {
     #[inline]
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         if buf.len() < 16 {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                ERROR_UNEXPECTED_LENGTH_OF_INPUT,
-            ));
+            return Err(Error::new(ErrorKind::InvalidInput, ERROR_UNEXPECTED_LENGTH_OF_INPUT));
         }
         let bytes: [u8; 16] = buf[..16].try_into().unwrap();
         let res = std::net::Ipv6Addr::from(bytes);

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -268,7 +268,9 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         let mut vec = self.iter().collect::<Vec<_>>();
         vec.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap());
-        u32::try_from(vec.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
+        u32::try_from(vec.len())
+            .map_err(|_| ErrorKind::InvalidInput)?
+            .serialize(writer)?;
         for (key, value) in vec {
             key.serialize(writer)?;
             value.serialize(writer)?;
@@ -285,7 +287,9 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         let mut vec = self.iter().collect::<Vec<_>>();
         vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        u32::try_from(vec.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
+        u32::try_from(vec.len())
+            .map_err(|_| ErrorKind::InvalidInput)?
+            .serialize(writer)?;
         for item in vec {
             item.serialize(writer)?;
         }
@@ -303,7 +307,9 @@ where
         // NOTE: BTreeMap iterates over the entries that are sorted by key, so the serialization
         // result will be consistent without a need to sort the entries as we do for HashMap
         // serialization.
-        u32::try_from(self.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
+        u32::try_from(self.len())
+            .map_err(|_| ErrorKind::InvalidInput)?
+            .serialize(writer)?;
         for (key, value) in self {
             key.serialize(writer)?;
             value.serialize(writer)?;
@@ -320,7 +326,9 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         // NOTE: BTreeSet iterates over the items that are sorted, so the serialization result will
         // be consistent without a need to sort the entries as we do for HashSet serialization.
-        u32::try_from(self.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
+        u32::try_from(self.len())
+            .map_err(|_| ErrorKind::InvalidInput)?
+            .serialize(writer)?;
         for item in self {
             item.serialize(writer)?;
         }

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -68,6 +68,12 @@ impl_for_integer!(u32);
 impl_for_integer!(u64);
 impl_for_integer!(u128);
 
+impl BorshSerialize for usize {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        BorshSerialize::serialize(&(*self as u64), writer)
+    }
+}
+
 // Note NaNs have a portability issue. Specifically, signalling NaNs on MIPS are quiet NaNs on x86,
 // and vice-versa. We disallow NaNs to avoid this issue.
 macro_rules! impl_for_float {
@@ -262,9 +268,7 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         let mut vec = self.iter().collect::<Vec<_>>();
         vec.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap());
-        u32::try_from(vec.len())
-            .map_err(|_| ErrorKind::InvalidInput)?
-            .serialize(writer)?;
+        u32::try_from(vec.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
         for (key, value) in vec {
             key.serialize(writer)?;
             value.serialize(writer)?;
@@ -281,9 +285,7 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         let mut vec = self.iter().collect::<Vec<_>>();
         vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        u32::try_from(vec.len())
-            .map_err(|_| ErrorKind::InvalidInput)?
-            .serialize(writer)?;
+        u32::try_from(vec.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
         for item in vec {
             item.serialize(writer)?;
         }
@@ -301,9 +303,7 @@ where
         // NOTE: BTreeMap iterates over the entries that are sorted by key, so the serialization
         // result will be consistent without a need to sort the entries as we do for HashMap
         // serialization.
-        u32::try_from(self.len())
-            .map_err(|_| ErrorKind::InvalidInput)?
-            .serialize(writer)?;
+        u32::try_from(self.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
         for (key, value) in self {
             key.serialize(writer)?;
             value.serialize(writer)?;
@@ -320,9 +320,7 @@ where
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         // NOTE: BTreeSet iterates over the items that are sorted, so the serialization result will
         // be consistent without a need to sort the entries as we do for HashSet serialization.
-        u32::try_from(self.len())
-            .map_err(|_| ErrorKind::InvalidInput)?
-            .serialize(writer)?;
+        u32::try_from(self.len()).map_err(|_| ErrorKind::InvalidInput)?.serialize(writer)?;
         for item in self {
             item.serialize(writer)?;
         }


### PR DESCRIPTION
As @olonho and other libs (serde, bincode, etc.) point out, this is not a hack, it serialize usize as if it were u64. It deserialize usize as if it were u64, and convert to usize. When overflow on deserialize, it return error