### PR TITLE
Remove hasher bound on map and set ser/de

### DIFF
--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -1,4 +1,5 @@
 use core::convert::TryFrom;
+use core::hash::BuildHasher;
 use core::mem::size_of;
 
 use crate::maybestd::{
@@ -259,10 +260,11 @@ where
     }
 }
 
-impl<K, V> BorshSerialize for HashMap<K, V>
+impl<K, V, H> BorshSerialize for HashMap<K, V, H>
 where
     K: BorshSerialize + PartialOrd,
     V: BorshSerialize,
+    H: BuildHasher,
 {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
@@ -279,9 +281,10 @@ where
     }
 }
 
-impl<T> BorshSerialize for HashSet<T>
+impl<T, H> BorshSerialize for HashSet<T, H>
 where
     T: BorshSerialize + PartialOrd,
+    H: BuildHasher,
 {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {

--- a/borsh/tests/test_hash_map.rs
+++ b/borsh/tests/test_hash_map.rs
@@ -1,0 +1,38 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::collections::{
+    hash_map::{DefaultHasher, RandomState},
+    HashMap,
+};
+use std::hash::BuildHasher;
+
+#[test]
+fn test_default_hashmap() {
+    let mut map = HashMap::new();
+    map.insert("foo".to_string(), "bar".to_string());
+    map.insert("one".to_string(), "two".to_string());
+
+    let data = map.try_to_vec().unwrap();
+    let actual_map = HashMap::<String, String>::try_from_slice(&data).unwrap();
+    assert_eq!(map, actual_map);
+}
+
+#[derive(Default)]
+struct NewHasher(RandomState);
+
+impl BuildHasher for NewHasher {
+    type Hasher = DefaultHasher;
+    fn build_hasher(&self) -> DefaultHasher {
+        self.0.build_hasher()
+    }
+}
+
+#[test]
+fn test_generic_hash_hashmap() {
+    let mut map = HashMap::with_hasher(NewHasher::default());
+    map.insert("foo".to_string(), "bar".to_string());
+    map.insert("one".to_string(), "two".to_string());
+
+    let data = map.try_to_vec().unwrap();
+    let actual_map = HashMap::<String, String, NewHasher>::try_from_slice(&data).unwrap();
+    assert_eq!(map, actual_map);
+}


### PR DESCRIPTION
Backport of changes I needed on Serum's fork https://github.com/project-serum/borsh-rs/pull/1

There is no need for the Hasher to be constrained to the default for serialize/deserialize impls