### PR TITLE
make schema same as de/serialization

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -165,7 +165,7 @@ macro_rules! impl_arrays {
     };
 }
 
-impl_arrays!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 32 64 65);
+impl_arrays!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 64 65 128 256 512 1024 2048);
 
 impl<T> BorshSchema for Option<T>
 where


### PR DESCRIPTION
make schema same as de/serialization for byte arrays