### PR TITLE
Add serialization helpers to improve api ergonomics

### DIFF
--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ser;
 pub use de::BorshDeserialize;
 pub use schema::BorshSchema;
 pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
+pub use ser::helpers::{serialize_to_vec, serialize_to_writer};
 pub use ser::BorshSerialize;
 
 /// A facade around all the types we need from the `std`, `core`, and `alloc`

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -13,7 +13,7 @@ pub mod ser;
 pub use de::BorshDeserialize;
 pub use schema::BorshSchema;
 pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
-pub use ser::helpers::{serialize_to_vec, serialize_to_writer};
+pub use ser::helpers::{to_vec, to_writer};
 pub use ser::BorshSerialize;
 
 /// A facade around all the types we need from the `std`, `core`, and `alloc`

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,0 +1,20 @@
+use crate::maybestd::io::{Result, Write};
+use crate::BorshSerialize;
+
+/// Serialize an object into a vector of bytes.
+#[inline]
+pub fn serialize_to_vec<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: BorshSerialize + ?Sized,
+{
+    value.try_to_vec()
+}
+
+/// Serializes an object directly into a `Writer`.
+#[inline]
+pub fn serialize_to_writer<T, W: Write>(value: &T, mut writer: W) -> Result<()>
+where
+    T: BorshSerialize + ?Sized,
+{
+    value.serialize(&mut writer)
+}

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,4 +1,7 @@
-use crate::maybestd::io::{Result, Write};
+use crate::maybestd::{
+    io::{Result, Write},
+    vec::Vec,
+};
 use crate::BorshSerialize;
 
 /// Serialize an object into a vector of bytes.

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -5,8 +5,7 @@ use crate::maybestd::{
 use crate::BorshSerialize;
 
 /// Serialize an object into a vector of bytes.
-#[inline]
-pub fn serialize_to_vec<T>(value: &T) -> Result<Vec<u8>>
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
     T: BorshSerialize + ?Sized,
 {
@@ -14,8 +13,7 @@ where
 }
 
 /// Serializes an object directly into a `Writer`.
-#[inline]
-pub fn serialize_to_writer<T, W: Write>(value: &T, mut writer: W) -> Result<()>
+pub fn to_writer<T, W: Write>(mut writer: W, value: &T) -> Result<()>
 where
     T: BorshSerialize + ?Sized,
 {

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -13,6 +13,8 @@ use crate::maybestd::{
 #[cfg(feature = "rc")]
 use std::{rc::Rc, sync::Arc};
 
+pub(crate) mod helpers;
+
 const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
 
 /// A data-structure that can be serialized into binary format by NBOR.

--- a/borsh/tests/smoke.rs
+++ b/borsh/tests/smoke.rs
@@ -1,0 +1,21 @@
+// Smoke tests that ensure that we don't accidentally remove top-level
+// re-exports in a minor release.
+
+use borsh::{self, BorshDeserialize};
+
+#[test]
+fn test_to_vec() {
+    let value = 42u8;
+    let serialized = borsh::to_vec(&value).unwrap();
+    let deserialized = u8::try_from_slice(&serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn test_to_writer() {
+    let value = 42u8;
+    let mut serialized = vec![0; 1];
+    borsh::to_writer(&mut serialized[..], &value).unwrap();
+    let deserialized = u8::try_from_slice(&serialized).unwrap();
+    assert_eq!(value, deserialized);
+}


### PR DESCRIPTION
Fixes: https://github.com/near/borsh-rs/issues/31

#### Problem
`BorshSerialize::serialize` method signature is not very ergonomic when using mutable slices. This is because a `&mut [T]` already implements `Write` but the method expects a `&mut W` where `W` itself implements `Write`. This means that in order to pass a mutable slice, you need to pass a mutable reference to the mutable slice: `&mut &mut [T]`.

#### Changes
- Added top-level `serialize_to_writer` and `serialize_to_vec` helper functions