### PR TITLE
feat: impl (de)ser for PhantomData

### DIFF
--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -3,6 +3,7 @@ use core::{
     hash::{BuildHasher, Hash},
     mem::{forget, size_of},
 };
+use std::marker::PhantomData;
 
 use crate::maybestd::{
     borrow::{Borrow, Cow, ToOwned},
@@ -581,5 +582,11 @@ where
 {
     fn deserialize(buf: &mut &[u8]) -> Result<Self> {
         Ok(T::Owned::deserialize(buf)?.into())
+    }
+}
+
+impl<T: ?Sized> BorshDeserialize for PhantomData<T> {
+    fn deserialize(_: &mut &[u8]) -> Result<Self> {
+        Ok(Self::default())
     }
 }

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -3,7 +3,7 @@ use core::{
     hash::{BuildHasher, Hash},
     mem::{forget, size_of},
 };
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::maybestd::{
     borrow::{Borrow, Cow, ToOwned},

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -1,9 +1,9 @@
+use core::marker::PhantomData;
 use core::{
     convert::{TryFrom, TryInto},
     hash::{BuildHasher, Hash},
     mem::{forget, size_of},
 };
-use core::marker::PhantomData;
 
 use crate::maybestd::{
     borrow::{Borrow, Cow, ToOwned},

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -1,6 +1,6 @@
 use core::convert::TryFrom;
 use core::hash::BuildHasher;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::maybestd::{
     borrow::{Cow, ToOwned},

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -1,5 +1,6 @@
 use core::convert::TryFrom;
 use core::hash::BuildHasher;
+use std::marker::PhantomData;
 
 use crate::maybestd::{
     borrow::{Cow, ToOwned},
@@ -501,5 +502,11 @@ impl<T: BorshSerialize + ?Sized> BorshSerialize for Rc<T> {
 impl<T: BorshSerialize + ?Sized> BorshSerialize for Arc<T> {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         (**self).serialize(writer)
+    }
+}
+
+impl<T: ?Sized> BorshSerialize for PhantomData<T> {
+    fn serialize<W: Write>(&self, _: &mut W) -> Result<()> {
+        Ok(())
     }
 }

--- a/borsh/tests/test_generic_struct.rs
+++ b/borsh/tests/test_generic_struct.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 

--- a/borsh/tests/test_generic_struct.rs
+++ b/borsh/tests/test_generic_struct.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
@@ -5,6 +7,7 @@ struct A<T, F, G> {
     x: Vec<T>,
     y: String,
     b: B<F, G>,
+    pd: PhantomData<T>,
     c: std::result::Result<T, G>,
     d: [u64; 5],
 }
@@ -19,6 +22,7 @@ enum B<F, G> {
 fn test_generic_struct() {
     let a = A::<String, u64, String> {
         x: vec!["foo".to_string(), "bar".to_string()],
+        pd: Default::default(),
         y: "world".to_string(),
         b: B::X { f: vec![1, 2] },
         c: Err("error".to_string()),


### PR DESCRIPTION
closes #30 

There is another option, which is to serialize a unit struct for the phantom data, similar to serde does by default. If this is done, possibly also schema can be added for it, otherwise, I don't think schema would work for this.