### PR TITLE
refactor!: alternate solution to zero size deserialization

### DIFF
--- a/borsh/src/de/hint.rs
+++ b/borsh/src/de/hint.rs
@@ -1,7 +1,7 @@
 #[inline]
-pub fn cautious<T>(hint: u32) -> usize {
-    let el_size = core::mem::size_of::<T>() as u32;
-    core::cmp::max(core::cmp::min(hint, 4096 / el_size), 1) as usize
+pub(crate) fn cautious<T>(hint: usize) -> usize {
+    let el_size = core::mem::size_of::<T>();
+    core::cmp::max(core::cmp::min(hint, 4096 / el_size), 1)
 }
 
 #[cfg(test)]
@@ -11,5 +11,10 @@ mod tests {
     #[test]
     pub fn test_cautious_u8() {
         assert_eq!(cautious::<u8>(10), 10);
+    }
+
+    #[test]
+    pub fn test_cautious_zero() {
+        assert_eq!(cautious::<u8>(0), 1);
     }
 }


### PR DESCRIPTION
So this doesn't solve the problem of #19, because there is still the potential DOS vector if zero size structs are used in any infra and the size is above the limit in this PR, but this is an alternative.

Seems like the issue is more around the number of bytes read during the deserialization, because you can do the same case with a sized struct, and things will go even worse than with a zero-sized one:

```rust
#[derive(PartialEq, Debug, Default)]
struct B {
    s: [String; 32],
    b: u64,
    c: [u64; 32],
}

impl BorshDeserialize for B {
    fn deserialize(_: &mut &[u8]) -> std::io::Result<Self> {
        Ok(Default::default())
    }
}

#[test]
fn test_deserialize_vector_to_many_zero_deserialize_bytes() {
    let v = [0u8, 0u8, 0u8, 64u8];
    let a = Vec::<B>::try_from_slice(&v).unwrap();
    assert_eq!(B::default(), a[usize::pow(2, 30) - 1]);
}
```

The temporary solution is to only resize where this edge case can potentially happen AND the length of the array is > 4096 (using limit from cautious allocation and the specific value doesn't matter). 

The other change I made is that when this case is hit, no values are serialized, where before exactly one element would be serialized no matter how many elements were in the vector. This seemed more consistent to me, but I'm happy to change this back if anyone has thoughts.

Just to clarify, I'm just working on this for fun and to understand the problem better and have no opinions on this. This PR can be dropped if this seems like more unexpected behaviour than before.