### PR TITLE
upgrade hashbrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.2
+- Upgrade hashbrown from `0.9` to `0.11`. This can breakage in the rare case
+  that you use borsh schema together with no-std support and rely on a specific
+  version hashbrown of `SchemaContainer`. This is considered to be obscure
+  enough to not warrant a semver bump.
+
 ## 0.9.1
 - Eliminated unsafe code from both ser and de of u8 (#26)
 - Implemented ser/de for reference count types (#27)
@@ -37,4 +43,3 @@
 - Added support for `std::borrow::Cow`
 - Avoid silent integer casts since they can lead to hidden security issues.
 - Removed `Cargo.lock` as it is advised for lib crates.
-

--- a/borsh-derive-internal/Cargo.toml
+++ b/borsh-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive-internal"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,8 +16,8 @@ Binary Object Representation Serializer for Hashing
 proc-macro = true
 
 [dependencies]
-borsh-derive-internal = { path = "../borsh-derive-internal", version="=0.9.1"}
-borsh-schema-derive-internal = { path = "../borsh-schema-derive-internal", version="=0.9.1"}
+borsh-derive-internal = { path = "../borsh-derive-internal", version="=0.9.2"}
+borsh-schema-derive-internal = { path = "../borsh-schema-derive-internal", version="=0.9.2"}
 syn = {version = "1", features = ["full", "fold"] }
 proc-macro-crate = "0.1.5"
 proc-macro2 = "1"

--- a/borsh-schema-derive-internal/Cargo.toml
+++ b/borsh-schema-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-schema-derive-internal"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -21,8 +21,8 @@ name = "generate_schema_schema"
 path = "src/generate_schema_schema.rs"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "=0.9.1" }
-hashbrown = "0.9.1"
+borsh-derive = { path = "../borsh-derive", version = "=0.9.2" }
+hashbrown = "0.11"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
The primary goal is to remove old hashbrown from nearcore. 

I considered making a larger change and actually hiding hashbrown altogether, but, on ballance, this seems like the best first step. If we want to break the API, there's quite a few things we might want to do #51 