### PR TITLE
fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: rust
 rust:
-  - 1.40.0
   - stable
   - beta
-  - nightly-2020-10-08  # this is what nearcore uses
-  - nightly
 
 matrix:
-  allow_failures:
-    - rust: nightly
   fast_finish: true
 
 branches:
@@ -20,7 +15,7 @@ install:
   - cargo build --verbose
 
 script:
-  - cargo fmt --all -- --check
+  - cargo fmt --check
   - cargo clippy --all-targets
   - cargo build --verbose
   - cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Borsh in Rust &emsp; [![Build Status]][travis-ci] [![Latest Version]][crates.io] [![borsh: rustc 1.40+]][Rust 1.40] [![License Apache-2.0 badge]][License Apache-2.0] [![License MIT badge]][License MIT]
+# Borsh in Rust &emsp; [![Build Status]][travis-ci] [![Latest Version]][crates.io] [![License Apache-2.0 badge]][License Apache-2.0] [![License MIT badge]][License MIT]
 
 [Borsh]: https://borsh.io
 [Build Status]: https://travis-ci.com/near/borsh-rs.svg?branch=master
 [travis-ci]: https://travis-ci.com/near/borsh-rs
 [Latest Version]: https://img.shields.io/crates/v/borsh.svg
 [crates.io]: https://crates.io/crates/borsh
-[borsh: rustc 1.40+]: https://img.shields.io/badge/rustc-1.40+-lightgray.svg
-[Rust 1.40]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html
 [License Apache-2.0 badge]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [License Apache-2.0]: https://opensource.org/licenses/Apache-2.0
 [License MIT badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
CI no longer works for 1.40, due to some dependency no longer being
compatible with it. Let's scale down our ambitious with respect to the
range of Rust version we intend to support to just the current stable.
Of course it would be *nice* to support more things, but we clearly
failing behind on that, with the current CI being broken on master.