### PR TITLE
feat: add `alloc` feature

### DIFF
--- a/benchmarks/benches/bench.rs
+++ b/benchmarks/benches/bench.rs
@@ -2,8 +2,7 @@ use benchmarks::{Account, Block, BlockHeader, Generate, SignedTransaction};
 use borsh::{BorshDeserialize, BorshSerialize};
 use rand::SeedableRng;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
-use speedy::Endianness;
-use speedy::{Readable, Writable};
+use speedy::{Endianness, Readable, Writable};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -25,7 +25,8 @@ borsh-derive = { path = "../borsh-derive", version = "=0.9.1" }
 hashbrown = "0.9.1"
 
 [features]
-default = ["std"]
+default = ["std", "alloc"]
 std = []
 rc = []
 const-generics = []
+alloc = []

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -1,19 +1,17 @@
+use core::convert::{TryFrom, TryInto};
+use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
-use core::{
-    convert::{TryFrom, TryInto},
-    hash::{BuildHasher, Hash},
-    mem::{forget, size_of},
-};
+use core::mem::{forget, size_of};
 
-use crate::maybestd::{
-    borrow::{Borrow, Cow, ToOwned},
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    format,
-    io::{Error, ErrorKind, Result},
-    string::{String, ToString},
-    vec::Vec,
+use crate::maybestd::borrow::{Borrow, Cow, ToOwned};
+use crate::maybestd::boxed::Box;
+use crate::maybestd::collections::{
+    BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque,
 };
+use crate::maybestd::format;
+use crate::maybestd::io::{Error, ErrorKind, Result};
+use crate::maybestd::string::{String, ToString};
+use crate::maybestd::vec::Vec;
 
 #[cfg(feature = "rc")]
 use std::{rc::Rc, sync::Arc};

--- a/borsh/src/nostd_io.rs
+++ b/borsh/src/nostd_io.rs
@@ -1,7 +1,8 @@
 //! Taken from https://github.com/bbqsrc/bare-io (with adjustments)
 
 use crate::maybestd::string::String;
-use core::{convert::From, fmt, result};
+use core::convert::From;
+use core::{fmt, result};
 
 /// A specialized [`Result`] type for I/O operations.
 ///

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -61,7 +61,7 @@ pub struct BorshSchemaContainer {
     /// Declaration of the type.
     pub declaration: Declaration,
     /// All definitions needed to deserialize the given type.
-    pub definitions: HashMap<Declaration, Definition>,
+    pub definitions: Vec<(Declaration, Definition)>,
 }
 
 /// The declaration and the definition of the type that can be used to (de)serialize Borsh without
@@ -95,7 +95,7 @@ pub trait BorshSchema {
         Self::add_definitions_recursively(&mut definitions);
         BorshSchemaContainer {
             declaration: Self::declaration(),
-            definitions,
+            definitions: definitions.into_iter().collect(),
         }
     }
 }

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -12,14 +12,12 @@
 
 #![allow(dead_code)] // Unclear why rust check complains on fields of `Definition` variants.
 use crate as borsh; // For `#[derive(BorshSerialize, BorshDeserialize)]`.
-use crate::maybestd::{
-    boxed::Box,
-    collections::{hash_map::Entry, HashMap},
-    format,
-    string::{String, ToString},
-    vec,
-    vec::Vec,
-};
+use crate::maybestd::boxed::Box;
+use crate::maybestd::collections::hash_map::Entry;
+use crate::maybestd::collections::HashMap;
+use crate::maybestd::string::{String, ToString};
+use crate::maybestd::vec::Vec;
+use crate::maybestd::{format, vec};
 use crate::{BorshDeserialize, BorshSchema as BorshSchemaMacro, BorshSerialize};
 
 /// The type that we use to represent the declaration of the Borsh type.

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -1,7 +1,5 @@
-use crate::maybestd::{
-    io::{Error, ErrorKind, Result},
-    vec::Vec,
-};
+use crate::maybestd::io::{Error, ErrorKind, Result};
+use crate::maybestd::vec::Vec;
 use crate::schema::BorshSchemaContainer;
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
 

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,7 +1,5 @@
-use crate::maybestd::{
-    io::{Result, Write},
-    vec::Vec,
-};
+use crate::maybestd::io::{Result, Write};
+use crate::maybestd::vec::Vec;
 use crate::BorshSerialize;
 
 /// Serialize an object into a vector of bytes.

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -281,6 +281,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<K, V, H> BorshSerialize for HashMap<K, V, H>
 where
     K: BorshSerialize + PartialOrd,
@@ -302,6 +303,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, H> BorshSerialize for HashSet<T, H>
 where
     T: BorshSerialize + PartialOrd,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -2,14 +2,14 @@ use core::convert::TryFrom;
 use core::hash::BuildHasher;
 use core::marker::PhantomData;
 
-use crate::maybestd::{
-    borrow::{Cow, ToOwned},
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    io::{ErrorKind, Result, Write},
-    string::String,
-    vec::Vec,
+use crate::maybestd::borrow::{Cow, ToOwned};
+use crate::maybestd::boxed::Box;
+use crate::maybestd::collections::{
+    BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque,
 };
+use crate::maybestd::io::{ErrorKind, Result, Write};
+use crate::maybestd::string::String;
+use crate::maybestd::vec::Vec;
 
 #[cfg(feature = "rc")]
 use std::{rc::Rc, sync::Arc};

--- a/borsh/tests/test_rc.rs
+++ b/borsh/tests/test_rc.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "rc")]
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use std::{rc::Rc, sync::Arc};
+use std::rc::Rc;
+use std::sync::Arc;
 
 #[test]
 fn test_rc_roundtrip() {


### PR DESCRIPTION
Rust is built around the concept of “zero cost abstraction”.

It's best not to hide extra allocation costs. I see, that by default there is an implementation available for `HashSet` and `HashMap`. It's a good idea to put it behind `alloc` feature.

In order not to break backwards compatibility, I added it to `default_features`.