### PR TITLE
feat(infra): introduce automated publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,17 +63,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install cargo-workspaces
+    - name: Setup
       run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         cargo install --git https://github.com/miraclx/cargo-workspaces --branch grouping-versioning-and-exclusion cargo-workspaces
-    - name: Publish to Crates.io and tag the commit responsible
+    - name: Publish to crates.io and tag the commit responsible
       run: |
         cargo ws publish --all --yes --exact \
           --skip-published --no-git-commit --allow-dirty \
-          --tag-existing --tag-prefix 'crates-' \
+          --tag-existing --tag-prefix 'v' \
           --tag-msg $'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}' \
           --no-individual-tags --no-git-push
     - name: Push tags to GitHub (if any)
-      run: |
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git push --follow-tags origin 'crates-*'
+      run: git push --tags

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,11 +74,11 @@ jobs:
         cargo ws publish --all --yes --exact \
           --skip-published --no-git-commit --allow-dirty \
           --tag-existing --tag-prefix 'v' \
-          --tag-msg 'crates.io snapshot' --tag-msg $'%{\n%n: https://crates.io/crates/%n/%v}' \
+          --tag-msg 'crates.io snapshot' --tag-msg $'%{\n - %n: https://crates.io/crates/%n/%v}' \
           --no-individual-tags --no-git-push
         echo "GIT_LATEST_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
         echo "Latest git tag is ${{ env.GIT_LATEST_TAG }}"
-        echo "::set-output name=git_tag::$(git tag -l --format='%(body)' ${{ env.GIT_LATEST_TAG }})"
+        echo "::set-output name=git_tag_message::$(git tag -l --format='%(body)' ${{ env.GIT_LATEST_TAG }})"
 
     - name: Push tags to GitHub (if any)
       run: git push --tags
@@ -97,6 +97,6 @@ jobs:
         body: |
           ${{ steps.extract-release-notes.outputs.release_notes }}
 
-          ### Crates.io Links
+          #### Crate Links
 
-          ${{ steps.version-tag-and-publish.outputs.git_tag }}
+          ${{ steps.version-tag-and-publish.outputs.git_tag_message }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Extract release notes
       id: extract-release-notes
-      uses: ffurrer2/extract-release-notes@v1
+      uses: ffurrer2/extract-release-notes@c24866884b7a0d2fd2095be2e406b6f260479da8
 
     - name: Create release
       uses: actions/create-release@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
         cargo install --git https://github.com/miraclx/cargo-workspaces --branch grouping-versioning-and-exclusion cargo-workspaces
     - name: Publish to Crates.io and tag the commit responsible
       run: |
-        cargo ws publish --all --yes \
+        cargo ws publish --all --yes --exact \
           --skip-published --no-git-commit --allow-dirty \
           --tag-existing --tag-prefix 'crates-' \
           --tag-msg $'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}' \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,3 +76,14 @@ jobs:
           --no-individual-tags --no-git-push
     - name: Push tags to GitHub (if any)
       run: git push --tags
+    - name: Extract release notes
+      id: extract-release-notes
+      uses: ffurrer2/extract-release-notes@v1
+    - name: Create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        body: ${{ steps.extract-release-notes.outputs.release_notes }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,7 @@ jobs:
           --tag-existing --tag-prefix 'v' \
           --tag-msg 'crates.io snapshot' --tag-msg $'%{\n - %n: https://crates.io/crates/%n/%v}' \
           --no-individual-tags --no-git-push
-        echo "GIT_LATEST_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
+        echo "GIT_LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
         echo "Latest git tag is ${{ env.GIT_LATEST_TAG }}"
         echo "::set-output name=git_tag_message::$(git tag -l --format='%(body)' ${{ env.GIT_LATEST_TAG }})"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,24 +66,37 @@ jobs:
     - name: Setup
       run: |
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        cargo install --git https://github.com/miraclx/cargo-workspaces --branch grouping-versioning-and-exclusion cargo-workspaces
+        cargo install --git https://github.com/miraclx/cargo-workspaces --rev b2d49b9e575e29fd2395352e4d0df47def025039 cargo-workspaces
+
     - name: Publish to crates.io and tag the commit responsible
+      id: version-tag-and-publish
       run: |
         cargo ws publish --all --yes --exact \
           --skip-published --no-git-commit --allow-dirty \
           --tag-existing --tag-prefix 'v' \
-          --tag-msg $'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}' \
+          --tag-msg 'crates.io snapshot' --tag-msg $'%{\n%n: https://crates.io/crates/%n/%v}' \
           --no-individual-tags --no-git-push
+        echo "GIT_LATEST_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
+        echo "Latest git tag is ${{ env.GIT_LATEST_TAG }}"
+        echo "::set-output name=git_tag::$(git tag -l --format='%(body)' ${{ env.GIT_LATEST_TAG }})"
+
     - name: Push tags to GitHub (if any)
       run: git push --tags
+
     - name: Extract release notes
       id: extract-release-notes
       uses: ffurrer2/extract-release-notes@v1
+
     - name: Create release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        body: ${{ steps.extract-release-notes.outputs.release_notes }}
+        tag_name: ${{ env.GIT_LATEST_TAG }}
+        release_name: ${{ env.GIT_LATEST_TAG }}
+        body: |
+          ${{ steps.extract-release-notes.outputs.release_notes }}
+
+          ### Crates.io Links
+
+          ${{ steps.version-tag-and-publish.outputs.git_tag }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,3 +55,25 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run cargo fmt
       run: cargo fmt --all -- --check
+
+  publish:
+    runs-on: ubuntu-20.04
+    needs: [tests, clippy, cargo-fmt]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install cargo-workspaces
+      run: |
+        cargo install --git https://github.com/miraclx/cargo-workspaces --branch grouping-versioning-and-exclusion cargo-workspaces
+    - name: Publish to Crates.io and tag the commit responsible
+      run: |
+        cargo ws publish --all --yes \
+          --skip-published --no-git-commit --allow-dirty \
+          --tag-existing --tag-prefix 'crates-' \
+          --tag-msg $'crates.io snapshot\n---%{\n- %n - https://crates.io/crates/%n/%v}' \
+          --no-individual-tags --no-git-push
+    - name: Push tags to GitHub (if any)
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git push --follow-tags origin 'crates-*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
-## 0.9.2
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.9.2] - 2022-01-25
+
 - Upgrade hashbrown from `0.9` to `0.11`. This can breakage in the rare case
   that you use borsh schema together with no-std support and rely on a specific
   version hashbrown of `SchemaContainer`. This is considered to be obscure
   enough to not warrant a semver bump.
 
-## 0.9.1
+## [0.9.1] - 2021-07-14
+
 - Eliminated unsafe code from both ser and de of u8 (#26)
 - Implemented ser/de for reference count types (#27)
 - Added serialization helpers to improve api ergonomics (#34)
@@ -15,31 +24,46 @@
 - Implemented const-generics under feature (#38)
 - Added an example of direct BorshSerialize::serialize usage with vector and slice buffers (#29)
 
-## 0.9.0
+## [0.9.0] - 2021-03-18
+
 - *BREAKING CHANGE*: `is_u8` optimization helper is now unsafe since it may
   cause undefined behavior if it returns `true` for the type that is not safe
   to Copy (#21)
 - Extended the schema impls to support longer arrays to match the
   de/serialization impls (#22)
 
-## 0.8.2
+## [0.8.2] - 2021-03-04
+
 - Avoid collisions of imports due to derive-generated code (#14)
 
-## 0.8.1
+## [0.8.1] - 2021-01-13
+
 - Added support for BTreeMap, BTreeSet, BinaryHeap, LinkedList, and VecDeque
 
-## 0.8.0
+## [0.8.0] - 2021-01-11
+
 - Add no_std support.
 
-## 0.7.2
+## [0.7.2] - 2021-01-14
+
 - Implement `BorshSerialize` for reference fields (`&T`)
 
-## 0.7.1
+## 0.7.1 - 2020-08-24
+
 - Implement `BorshSerialize` for `&T` if `T` implements `BorshSerialize`.
 
-## 0.7.0
+## 0.7.0 - 2020-06-17
 
 - Extended `Box<T>` implementation for `?Sized` types (`[T]`, `str`, ...).
 - Added support for `std::borrow::Cow`
 - Avoid silent integer casts since they can lead to hidden security issues.
 - Removed `Cargo.lock` as it is advised for lib crates.
+
+[unreleased]: https://github.com/near/borsh-rs/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/near/borsh-rs/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/near/borsh-rs/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/near/borsh-rs/compare/v0.8.2...v0.9.0
+[0.8.2]: https://github.com/near/borsh-rs/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/near/borsh-rs/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/near/borsh-rs/compare/v0.7.2...v0.8.0
+[0.7.2]: https://github.com/near/borsh-rs/releases/tag/v0.7.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ members = [
 
 [workspace.metadata.workspaces]
 version = "0.9.2"
+exclude = [ "fuzz/*", "benchmarks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ members = [
 ]
 
 [workspace.metadata.workspaces]
+# shared version of all public crates in the workspace
 version = "0.9.2"
 exclude = [ "fuzz/*", "benchmarks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ members = [
     "borsh-derive",
     "borsh-derive-internal",
     "borsh-schema-derive-internal",
+    "fuzz/fuzz-run",
     "benchmarks",
-]
-exclude = [
-    "fuzz",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "fuzz/fuzz-run",
     "benchmarks",
 ]
+
+[workspace.metadata.workspaces]
+version = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -78,38 +78,21 @@ struct A {
 
 ## Releasing
 
-Before you release, make sure CHANGELOG.md is up to date.
+The versions of all public crates in this repository are collectively managed by a single version in the [workspace manifest](https://github.com/near/borsh-rs/blob/master/Cargo.toml).
 
-Use [`cargo-workspaces`](https://github.com/pksunkara/cargo-workspaces) to save time.
+So, to publish a new version of all the crates, you can do so by simply bumping that to the next "patch" version and submit a PR.
 
-### Bump Versions
+We have CI Infrastructure put in place to automate the process of publishing all crates once a version change has merged into master.
 
-```sh
-cargo workspaces version --force 'borsh*' --exact --no-individual-tags patch
-```
-
-This will bump all the versions to the next "patch" release (see `cargo workspaces version --help`
-for more options), create a new commit, push `v0.x.x` tag, push to the master.
-
-### Publish
-
-To publish on crates.io the version that is currently in git:
-
-```sh
-cargo workspaces publish --from-git --skip-published
-```
-
-Alternatively, you may want to combine the version bumping with publishing:
-
-```sh
-cargo workspaces publish --force 'borsh*' --exact --no-individual-tags patch
-```
+However, before you release, make sure the [CHANGELOG](CHANGELOG.md) is up to date.
 
 ### Release on GitHub
 
+After the checks pass and the release to crates.io has succeeded, a new tag will be created on GitHub to match the new version. You can use this tag to manually create a new release on GitHub.
+
 1. Navigate to the [New Release](https://github.com/near/borsh-rs/releases/new) page
-2. Enter the tag name, e.g. `v0.8.0`
-3. Write down the release log (basically, copy-paste from the CHANGELOG)
+2. Select the tag name, e.g. `v0.8.0`
+3. Write down the release log (basically, copy-paste from the [CHANGELOG](CHANGELOG.md))
 4. Publish the release
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,16 +84,7 @@ So, to publish a new version of all the crates, you can do so by simply bumping 
 
 We have CI Infrastructure put in place to automate the process of publishing all crates once a version change has merged into master.
 
-However, before you release, make sure the [CHANGELOG](CHANGELOG.md) is up to date.
-
-### Release on GitHub
-
-After the checks pass and the release to crates.io has succeeded, a new tag will be created on GitHub to match the new version. You can use this tag to manually create a new release on GitHub.
-
-1. Navigate to the [New Release](https://github.com/near/borsh-rs/releases/new) page
-2. Select the tag name, e.g. `v0.8.0`
-3. Write down the release log (basically, copy-paste from the [CHANGELOG](CHANGELOG.md))
-4. Publish the release
+However, before you release, make sure the [CHANGELOG](CHANGELOG.md) is up to date and that the `[Unreleased]` section is present but empty.
 
 ## License
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,6 +3,7 @@ name = "benchmarks"
 version = "0.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
+publish = false
 
 # This is somehow needed for command line arguments to work: https://github.com/bheisler/criterion.rs/issues/193#issuecomment-415740713
 [lib]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 publish = false

--- a/borsh-derive-internal/Cargo.toml
+++ b/borsh-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive-internal"
-version = "0.9.2"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -16,8 +16,8 @@ Binary Object Representation Serializer for Hashing
 proc-macro = true
 
 [dependencies]
-borsh-derive-internal = { path = "../borsh-derive-internal", version="=0.9.2"}
-borsh-schema-derive-internal = { path = "../borsh-schema-derive-internal", version="=0.9.2"}
+borsh-derive-internal = { path = "../borsh-derive-internal" }
+borsh-schema-derive-internal = { path = "../borsh-schema-derive-internal" }
 syn = {version = "1", features = ["full", "fold"] }
 proc-macro-crate = "0.1.5"
 proc-macro2 = "1"

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-derive"
-version = "0.9.2"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh-schema-derive-internal/Cargo.toml
+++ b/borsh-schema-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-schema-derive-internal"
-version = "0.9.2"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh"
-version = "0.9.2"
+version = "0.0.0"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -21,7 +21,7 @@ name = "generate_schema_schema"
 path = "src/generate_schema_schema.rs"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "=0.9.2" }
+borsh-derive = { path = "../borsh-derive" }
 hashbrown = "0.11"
 
 [features]

--- a/fuzz/fuzz-run/Cargo.toml
+++ b/fuzz/fuzz-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "borsh-fuzz"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
This PR introduces a CI job that automates versioning and publishing borsh-rs crates to crates.io.

#### Here's what the tag page should look like:

![Screenshot_20220125_183624](https://user-images.githubusercontent.com/16881812/151029273-37f4ccb1-bc00-4cb3-afa4-51d27b908a13.png)

#### Here's what the release page should look like:

![Screenshot_20220125_184422](https://user-images.githubusercontent.com/16881812/151030561-bff32213-8919-4794-a512-01f3ceb4de10.png)