### PR TITLE
fix(infra): add git author name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup
       run: |
+        git config user.name github-actions
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         cargo install --git https://github.com/miraclx/cargo-workspaces --rev b2d49b9e575e29fd2395352e4d0df47def025039 cargo-workspaces
 


### PR DESCRIPTION
Patches #67, specifies a git author name.

Fixes CI run https://github.com/near/borsh-rs/runs/4943023986?check_suite_focus=true