### PR TITLE
fix(infra): env variables

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,9 +77,10 @@ jobs:
           --tag-existing --tag-prefix 'v' \
           --tag-msg 'crates.io snapshot' --tag-msg $'%{\n - %n: https://crates.io/crates/%n/%v}' \
           --no-individual-tags --no-git-push
-        echo "GIT_LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-        echo "Latest git tag is ${{ env.GIT_LATEST_TAG }}"
-        echo "::set-output name=git_tag_message::$(git tag -l --format='%(body)' ${{ env.GIT_LATEST_TAG }})"
+        export GIT_LATEST_TAG=$(git describe --tags --abbrev=0)
+        echo "GIT_LATEST_TAG=${GIT_LATEST_TAG}" >> $GITHUB_ENV
+        echo "Latest git tag is ${GIT_LATEST_TAG}"
+        echo "::set-output name=git_tag_message::$(git tag -l --format='%(body)' ${GIT_LATEST_TAG})"
 
     - name: Push tags to GitHub (if any)
       run: git push --tags

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,8 @@ jobs:
 
     - name: Publish to crates.io and tag the commit responsible
       id: version-tag-and-publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         cargo ws publish --all --yes --exact \
           --skip-published --no-git-commit --allow-dirty \


### PR DESCRIPTION
Patches #67

- Imports the `CARGO_REGISTRY_TOKEN` secret env into the step, according to https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv
  Fixes https://github.com/near/borsh-rs/runs/4945511243?check_suite_focus=true

  > ```yml
  >   steps:
  >     - name: My first action
  >       env:
  >         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  >   ```

- Fixes a use-case for `$GITHUB_ENV`, according to https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable;

  > The step that creates or updates the environment variable does not have access to the new value, but all subsequent steps in a job will have access.