### PR TITLE
fixes maybstd imports for no_std on thumbv6m-none-eabi

### DIFF
--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -21,7 +21,10 @@ pub use ser::BorshSerialize;
 /// module.
 #[cfg(feature = "std")]
 pub mod maybestd {
-    pub use std::{borrow, boxed, collections, format, io, rc, string, sync, vec};
+    pub use std::{borrow, boxed, collections, format, io, string, vec};
+
+    #[cfg(feature = "rc")]
+    pub use std::{rc, sync};
 }
 
 #[cfg(not(feature = "std"))]
@@ -29,7 +32,10 @@ mod nostd_io;
 
 #[cfg(not(feature = "std"))]
 pub mod maybestd {
-    pub use alloc::{borrow, boxed, format, rc, string, sync, vec};
+    pub use alloc::{borrow, boxed, format, string, vec};
+
+    #[cfg(feature = "rc")]
+    pub use alloc::{rc, sync};
 
     pub mod collections {
         pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};


### PR DESCRIPTION
I'm having a tiny bit of trouble getting my Cargo workspace to completely work with patches, paths, a 0.0.0 version for this library and a few other build dep things, but I think this fixes the inability to use `borsh` in `no_std` b/c a failure to `use alloc::sync` on line 32. 

The remainder of the changes are just in keeping with the rest of the codebase, which only depends on `rc` and `sync` when `cfg(feature = "rc")`