### PR TITLE
fix: remove inconsistent duplicate hashbrown imports

### DIFF
--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -39,10 +39,4 @@ pub mod maybestd {
     pub mod io {
         pub use super::super::nostd_io::*;
     }
-
-    pub use hashbrown::{HashMap, HashSet};
-
-    pub mod hash_map {
-        pub use hashbrown::hash_map::Entry;
-    }
 }


### PR DESCRIPTION
breaking change so I split it from #88 but this was noticed when making that change.

Is there some reason this was exported directly from the maybestd module before? Will this break anything?