### PR TITLE
Skip adding the where clause to avoid triggering overflow

### DIFF
--- a/borsh-derive-internal/src/attribute_helpers.rs
+++ b/borsh-derive-internal/src/attribute_helpers.rs
@@ -13,6 +13,17 @@ pub fn contains_skip(attrs: &[Attribute]) -> bool {
     false
 }
 
+pub fn contains_exclude_from_where(attrs: &[Attribute]) -> bool {
+    for attr in attrs.iter() {
+        if let Ok(Meta::Path(path)) = attr.parse_meta() {
+            if path.to_token_stream().to_string().as_str() == "borsh_exclude_from_where" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 pub fn contains_initialize_with(attrs: &[Attribute]) -> syn::Result<Option<Path>> {
     for attr in attrs.iter() {
         if let Ok(Meta::List(meta_list)) = attr.parse_meta() {

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -30,7 +30,7 @@ pub fn borsh_serialize(input: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(BorshDeserialize, attributes(borsh_skip, borsh_init))]
+#[proc_macro_derive(BorshDeserialize, attributes(borsh_skip, borsh_init, borsh_exclude_from_where))]
 pub fn borsh_deserialize(input: TokenStream) -> TokenStream {
     let cratename = Ident::new(
         &crate_name("borsh").unwrap_or_else(|_| "borsh".to_string()),

--- a/borsh/tests/test_recursive_enum.rs
+++ b/borsh/tests/test_recursive_enum.rs
@@ -1,0 +1,19 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+enum A {
+    B,
+    C {
+        #[borsh_exclude_from_where]
+        d: Vec<A>,
+    },
+}
+
+#[test]
+fn test_recursive_enum() {
+    let a = A::C { d: vec![A::B] };
+    let encoded = a.try_to_vec().unwrap();
+    let decoded = A::try_from_slice(&encoded).unwrap();
+
+    assert_eq!(A::C { d: vec![A::B] }, decoded);
+}


### PR DESCRIPTION
# Problem

```rust
#[derive(BorshSerialize, BorshDeserialize)]
enum A {
    B,
    C {
        d: Vec<A>,
    },
}
```

gives `overflow evaluating the requirement A: BorshDeserialize` or BorshSerialize

# Idea

Allow skipping adding to the where clause with an attribute to allow edge cases to function.

I am told this could help https://github.com/rust-lang/rust/issues/48214 but there is currently no way to achieve the same effect "working for recursive data structure" by determining automatically which where clause to add in the proc_macro

Not complete yet as this attribute only has an effect for an `enum`

# Related issues
https://github.com/near/borsh-rs/issues/7