### PR TITLE
feat: impl ser/de and schema for `(T,)`

### DIFF
--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -588,7 +588,7 @@ impl BorshDeserialize for () {
 
 macro_rules! impl_tuple {
     ($($name:ident)+) => {
-      impl<$($name),+> BorshDeserialize for ($($name),+)
+      impl<$($name),+> BorshDeserialize for ($($name,)+)
       where $($name: BorshDeserialize,)+
       {
         #[inline]
@@ -600,6 +600,7 @@ macro_rules! impl_tuple {
     };
 }
 
+impl_tuple!(T0);
 impl_tuple!(T0 T1);
 impl_tuple!(T0 T1 T2);
 impl_tuple!(T0 T1 T2 T3);

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -303,7 +303,7 @@ where
 
 macro_rules! impl_tuple {
     ($($name:ident),+) => {
-    impl<$($name),+> BorshSchema for ($($name),+)
+    impl<$($name),+> BorshSchema for ($($name,)+)
     where
         $($name: BorshSchema),+
     {
@@ -325,6 +325,7 @@ macro_rules! impl_tuple {
     };
 }
 
+impl_tuple!(T0);
 impl_tuple!(T0, T1);
 impl_tuple!(T0, T1, T2);
 impl_tuple!(T0, T1, T2, T3);

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -511,7 +511,7 @@ impl BorshSerialize for () {
 
 macro_rules! impl_tuple {
     ($($idx:tt $name:ident)+) => {
-      impl<$($name),+> BorshSerialize for ($($name),+)
+      impl<$($name),+> BorshSerialize for ($($name,)+)
       where $($name: BorshSerialize,)+
       {
         #[inline]
@@ -523,6 +523,7 @@ macro_rules! impl_tuple {
     };
 }
 
+impl_tuple!(0 T0);
 impl_tuple!(0 T0 1 T1);
 impl_tuple!(0 T0 1 T1 2 T2);
 impl_tuple!(0 T0 1 T1 2 T2 3 T3);

--- a/borsh/tests/test_schema_tuple.rs
+++ b/borsh/tests/test_schema_tuple.rs
@@ -1,0 +1,28 @@
+use borsh::maybestd::collections::HashMap;
+use borsh::schema::*;
+
+macro_rules! map(
+    () => { HashMap::new() };
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = HashMap::new();
+            $(
+                m.insert($key.to_string(), $value);
+            )+
+            m
+        }
+     };
+);
+
+#[test]
+fn test_unary_tuple_schema() {
+    assert_eq!("Tuple<bool>", <(bool,)>::declaration());
+    let mut defs = Default::default();
+    <(bool,)>::add_definitions_recursively(&mut defs);
+    assert_eq!(
+        map! {
+        "Tuple<bool>" => Definition::Tuple { elements: vec!["bool".to_string()] }
+        },
+        defs
+    );
+}

--- a/borsh/tests/test_tuple.rs
+++ b/borsh/tests/test_tuple.rs
@@ -1,0 +1,9 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[test]
+fn test_unary_tuple() {
+    let expected = (true,);
+    let buf = expected.try_to_vec().unwrap();
+    let actual = <(bool,)>::try_from_slice(&buf).expect("failed to deserialize");
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Not sure if unary tuples were left out on purpose, but seems sensible to me to support them