### PR TITLE
fix: delete schema for `char`

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -142,7 +142,7 @@ macro_rules! impl_for_primitives {
     };
 }
 
-impl_for_primitives!(bool char f32 f64 i8 i16 i32 i64 i128 u8 u16 u32 u64 u128);
+impl_for_primitives!(bool f32 f64 i8 i16 i32 i64 i128 u8 u16 u32 u64 u128);
 impl_for_renamed_primitives!(String: string);
 impl_for_renamed_primitives!(str: string);
 impl_for_renamed_primitives!(isize: i64);


### PR DESCRIPTION
There are no ser/de impls for `char` and it is not a part of the spec, so seems like this was derived by mistake