### PR TITLE
fix: codegen sanity for enum serialization

### DIFF
--- a/borsh-derive-internal/src/enum_de.rs
+++ b/borsh-derive-internal/src/enum_de.rs
@@ -77,7 +77,7 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     #variant_idx
                     let mut return_value = match variant_idx {
                         #variant_arms
@@ -98,7 +98,7 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
     } else {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     #variant_idx
                     let return_value = match variant_idx {
                         #variant_arms

--- a/borsh-derive-internal/src/enum_ser.rs
+++ b/borsh-derive-internal/src/enum_ser.rs
@@ -94,7 +94,7 @@ pub fn enum_ser(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2>
     }
     Ok(quote! {
         impl #impl_generics #cratename::ser::BorshSerialize for #name #ty_generics #where_clause {
-            fn serialize<W: #cratename::maybestd::io::Write>(&self, writer: &mut W) -> core::result::Result<(), #cratename::maybestd::io::Error> {
+            fn serialize<W: #cratename::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::maybestd::io::Error> {
                 let variant_idx: u8 = match self {
                     #variant_idx_body
                 };

--- a/borsh/tests/test_macro_namespace_collisions.rs
+++ b/borsh/tests/test_macro_namespace_collisions.rs
@@ -5,3 +5,9 @@ mod core {}
 
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 struct A;
+
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+enum B {
+    C,
+    D,
+}


### PR DESCRIPTION
structs were fixed in https://github.com/near/borsh-rs/commit/985a20b0289b034a53fe6b2e3c799349d8cbd95f but this was not done for enums.

cc @BenKurrek