### PR TITLE
fix: remove unnecessary trait bounds requirements for array

### DIFF
--- a/borsh/tests/test_arrays.rs
+++ b/borsh/tests/test_arrays.rs
@@ -44,3 +44,22 @@ test_arrays!(
 );
 test_arrays!(test_array_f32, 1000000000.0f32, f32);
 test_arrays!(test_array_array_u8, [100u8; 32], [u8; 32]);
+
+#[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
+struct CustomStruct(u8);
+
+#[test]
+fn test_custom_struct_array() {
+    let arr = [CustomStruct(0), CustomStruct(1), CustomStruct(2)];
+    let serialized = arr.try_to_vec().unwrap();
+    let deserialized: [CustomStruct; 3] = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    assert_eq!(arr, deserialized);
+}
+
+#[test]
+fn test_string_array() {
+    let arr = ["0".to_string(), "1".to_string(), "2".to_string()];
+    let serialized = arr.try_to_vec().unwrap();
+    let deserialized: [String; 3] = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    assert_eq!(arr, deserialized);
+}


### PR DESCRIPTION
So this is technically a breaking change, but only to the `copy_from_bytes` function, which is hidden from docs. Unclear if that is acceptable breakage. Unclear the exact implications of this yet, but it seems like it would be more optimized since it doesn't require calling `Default` and then copying the value to initialize the value, but might lose some performance switching from `copy_from_slice` to iterating over the buffer and copying each u8 individually.

I will look more in-depth when I'm on better internet to check the safety of this cast for the transmute workaround. I have low confidence about that unsafe code currently.

closes #103 