### PR TITLE
chore: remove const-generics feature impls

### DIFF
--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -526,44 +526,6 @@ where
     }
 }
 
-#[cfg(not(feature = "const-generics"))]
-const _: () = {
-    macro_rules! impl_arrays {
-        ($($len:expr)+) => {
-        $(
-            impl<T> BorshDeserialize for [T; $len]
-            where
-                T: BorshDeserialize + Default + Copy
-            {
-                #[inline]
-                fn deserialize(buf: &mut &[u8]) -> Result<Self> {
-                    let mut result = [T::default(); $len];
-                    if !T::copy_from_bytes(buf, &mut result)? {
-                        for i in 0..$len {
-                            result[i] = T::deserialize(buf)?;
-                        }
-                    }
-                    Ok(result)
-                }
-            }
-        )+
-        };
-    }
-
-    impl_arrays!(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 64 65 128 256 512 1024 2048);
-
-    impl<T> BorshDeserialize for [T; 0]
-    where
-        T: BorshDeserialize + Default + Copy,
-    {
-        #[inline]
-        fn deserialize(_buf: &mut &[u8]) -> Result<Self> {
-            Ok([T::default(); 0])
-        }
-    }
-};
-
-#[cfg(feature = "const-generics")]
 impl<T, const N: usize> BorshDeserialize for [T; N]
 where
     T: BorshDeserialize + Default + Copy,

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -148,32 +148,6 @@ impl_for_renamed_primitives!(str: string);
 impl_for_renamed_primitives!(isize: i64);
 impl_for_renamed_primitives!(usize: u64);
 
-#[cfg(not(feature = "const-generics"))]
-const _: () = {
-    macro_rules! impl_arrays {
-        ($($len:expr)+) => {
-        $(
-        impl<T> BorshSchema for [T; $len]
-        where
-            T: BorshSchema,
-        {
-            fn add_definitions_recursively(definitions: &mut HashMap<Declaration, Definition>) {
-                let definition = Definition::Array { length: $len, elements: T::declaration() };
-                Self::add_definition(Self::declaration(), definition, definitions);
-                T::add_definitions_recursively(definitions);
-            }
-            fn declaration() -> Declaration {
-                format!(r#"Array<{}, {}>"#, T::declaration(), $len)
-            }
-        }
-        )+
-        };
-    }
-
-    impl_arrays!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 64 65 128 256 512 1024 2048);
-};
-
-#[cfg(feature = "const-generics")]
 impl<T, const N: usize> BorshSchema for [T; N]
 where
     T: BorshSchema,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -446,44 +446,6 @@ impl<T: BorshSerialize + ?Sized> BorshSerialize for Box<T> {
     }
 }
 
-#[cfg(not(feature = "const-generics"))]
-const _: () = {
-    macro_rules! impl_arrays {
-        ($($len:expr)+) => {
-        $(
-            impl<T> BorshSerialize for [T; $len]
-            where T: BorshSerialize
-            {
-                #[inline]
-                fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-                    if let Some(u8_slice) = T::u8_slice(self) {
-                        writer.write_all(u8_slice)?;
-                    } else {
-                        for el in self.iter() {
-                            el.serialize(writer)?;
-                        }
-                    }
-                    Ok(())
-                }
-            }
-        )+
-        };
-    }
-
-    impl<T> BorshSerialize for [T; 0]
-    where
-        T: BorshSerialize,
-    {
-        #[inline]
-        fn serialize<W: Write>(&self, _writer: &mut W) -> Result<()> {
-            Ok(())
-        }
-    }
-
-    impl_arrays!(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 64 65 128 256 512 1024 2048);
-};
-
-#[cfg(feature = "const-generics")]
 impl<T, const N: usize> BorshSerialize for [T; N]
 where
     T: BorshSerialize,


### PR DESCRIPTION
MSRV is already past const generics (`1.55.0`), so these specialized impls can be removed. I haven't removed the feature itself to avoid being a breaking change.

I made this change in #104 but separated to here because it is an isolated change.