### PR TITLE
implement deserialize_reader

### DIFF
--- a/borsh-derive-internal/src/enum_de.rs
+++ b/borsh-derive-internal/src/enum_de.rs
@@ -40,7 +40,7 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
                         );
 
                         variant_header.extend(quote! {
-                            #field_name: #cratename::BorshDeserialize::deserialize(buf)?,
+                            #field_name: #cratename::BorshDeserialize::deserialize_reader(reader)?,
                         });
                     }
                 }
@@ -59,8 +59,9 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
                             .unwrap(),
                         );
 
-                        variant_header
-                            .extend(quote! { #cratename::BorshDeserialize::deserialize(buf)?, });
+                        variant_header.extend(
+                            quote! { #cratename::BorshDeserialize::deserialize_reader(reader)?, },
+                        );
                     }
                 }
                 variant_header = quote! { ( #variant_header )};
@@ -72,12 +73,12 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
         });
     }
     let variant_idx = quote! {
-        let variant_idx: u8 = #cratename::BorshDeserialize::deserialize(buf)?;
+        let variant_idx: u8 = #cratename::BorshDeserialize::deserialize_reader(reader)?;
     };
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     #variant_idx
                     let mut return_value = match variant_idx {
                         #variant_arms
@@ -98,7 +99,7 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
     } else {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     #variant_idx
                     let return_value = match variant_idx {
                         #variant_arms

--- a/borsh-derive-internal/src/struct_de.rs
+++ b/borsh-derive-internal/src/struct_de.rs
@@ -34,7 +34,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
                     );
 
                     quote! {
-                        #field_name: #cratename::BorshDeserialize::deserialize(buf)?,
+                        #field_name: #cratename::BorshDeserialize::deserialize_reader(reader)?,
                     }
                 };
                 body.extend(delta);
@@ -47,7 +47,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
             let mut body = TokenStream2::new();
             for _ in 0..fields.unnamed.len() {
                 let delta = quote! {
-                    #cratename::BorshDeserialize::deserialize(buf)?,
+                    #cratename::BorshDeserialize::deserialize_reader(reader)?,
                 };
                 body.extend(delta);
             }
@@ -64,7 +64,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     let mut return_value = #return_value;
                     return_value.#method_ident();
                     Ok(return_value)
@@ -74,7 +74,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
     } else {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
                     Ok(#return_value)
                 }
             }

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -468,8 +468,7 @@ impl BorshDeserialize for std::net::Ipv4Addr {
         reader
             .read_exact(&mut buf)
             .map_err(unexpected_eof_to_unexpected_length_of_input)?;
-        let bytes: [u8; 4] = buf.try_into().unwrap();
-        Ok(std::net::Ipv4Addr::from(bytes))
+        Ok(std::net::Ipv4Addr::from(buf))
     }
 }
 
@@ -481,8 +480,7 @@ impl BorshDeserialize for std::net::Ipv6Addr {
         reader
             .read_exact(&mut buf)
             .map_err(unexpected_eof_to_unexpected_length_of_input)?;
-        let bytes: [u8; 16] = buf.try_into().unwrap();
-        Ok(std::net::Ipv6Addr::from(bytes))
+        Ok(std::net::Ipv6Addr::from(buf))
     }
 }
 

--- a/borsh/tests/test_custom_reader.rs
+++ b/borsh/tests/test_custom_reader.rs
@@ -1,0 +1,139 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+struct Serializable {
+    item1: i32,
+    item2: String,
+    item3: f64,
+}
+
+#[test]
+fn test_custom_reader() {
+    let s = Serializable {
+        item1: 100,
+        item2: "foo".into(),
+        item3: 1.2345,
+    };
+    let bytes = s.try_to_vec().unwrap();
+    let mut reader = CustomReader {
+        data: bytes,
+        read_index: 0,
+    };
+    let de: Serializable = BorshDeserialize::deserialize_reader(&mut reader).unwrap();
+    assert_eq!(de.item1, s.item1);
+    assert_eq!(de.item2, s.item2);
+    assert_eq!(de.item3, s.item3);
+}
+
+#[test]
+fn test_custom_reader_with_insufficient_data() {
+    let s = Serializable {
+        item1: 100,
+        item2: "foo".into(),
+        item3: 1.2345,
+    };
+    let mut bytes = s.try_to_vec().unwrap();
+    bytes.pop().unwrap();
+    let mut reader = CustomReader {
+        data: bytes,
+        read_index: 0,
+    };
+    assert_eq!(
+        <Serializable as BorshDeserialize>::deserialize_reader(&mut reader)
+            .unwrap_err()
+            .to_string(),
+        ERROR_UNEXPECTED_LENGTH_OF_INPUT
+    );
+}
+
+#[test]
+fn test_custom_reader_with_too_much_data() {
+    let s = Serializable {
+        item1: 100,
+        item2: "foo".into(),
+        item3: 1.2345,
+    };
+    let mut bytes = s.try_to_vec().unwrap();
+    bytes.pop().unwrap();
+    let mut reader = CustomReader {
+        data: bytes,
+        read_index: 0,
+    };
+    assert_eq!(
+        <Serializable as BorshDeserialize>::try_from_reader(&mut reader)
+            .unwrap_err()
+            .to_string(),
+        ERROR_UNEXPECTED_LENGTH_OF_INPUT
+    );
+}
+
+struct CustomReader {
+    data: Vec<u8>,
+    read_index: usize,
+}
+
+impl borsh::maybestd::io::Read for CustomReader {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
+        let len = buf.len().min(self.data.len() - self.read_index);
+        buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
+        self.read_index += len;
+        Ok(len)
+    }
+}
+
+#[test]
+fn test_custom_reader_that_doesnt_fill_slices() {
+    let s = Serializable {
+        item1: 100,
+        item2: "foo".into(),
+        item3: 1.2345,
+    };
+    let bytes = s.try_to_vec().unwrap();
+    let mut reader = CustomReaderThatDoesntFillSlices {
+        data: bytes,
+        read_index: 0,
+    };
+    let de: Serializable = BorshDeserialize::deserialize_reader(&mut reader).unwrap();
+    assert_eq!(de.item1, s.item1);
+    assert_eq!(de.item2, s.item2);
+    assert_eq!(de.item3, s.item3);
+}
+
+struct CustomReaderThatDoesntFillSlices {
+    data: Vec<u8>,
+    read_index: usize,
+}
+
+impl borsh::maybestd::io::Read for CustomReaderThatDoesntFillSlices {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
+        let len = buf.len().min(self.data.len() - self.read_index);
+        let len = if len <= 1 { len } else { len / 2 };
+        buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
+        self.read_index += len;
+        Ok(len)
+    }
+}
+
+#[test]
+fn test_custom_reader_that_fails_preserves_error_information() {
+    let mut reader = CustomReaderThatFails;
+    let err = <Serializable as BorshDeserialize>::try_from_reader(&mut reader).unwrap_err();
+    assert_eq!(err.to_string(), "I don't like to run");
+    assert_eq!(
+        err.kind(),
+        borsh::maybestd::io::ErrorKind::ConnectionAborted
+    );
+}
+
+struct CustomReaderThatFails;
+
+impl borsh::maybestd::io::Read for CustomReaderThatFails {
+    fn read(&mut self, _buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
+        Err(borsh::maybestd::io::Error::new(
+            borsh::maybestd::io::ErrorKind::ConnectionAborted,
+            "I don't like to run",
+        ))
+    }
+}


### PR DESCRIPTION
Add support for deserialization of data within an `std::io::Read`.

This is a breaking change. The old `deserialize` API is still available for consumers of the crate, but code that uses the `BorshDeserialize` derive macro needs to be re-compiled, as the macro definition has changed.