### PR TITLE
chore: bump hashbrown to 0.13

### DIFF
--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/generate_schema_schema.rs"
 
 [dependencies]
 borsh-derive = { path = "../borsh-derive" }
-hashbrown = "0.11"
+hashbrown = "0.13"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

We hope to dedup the different crossbeam versions in our projects, thanks!