### PR TITLE
release: Prepare for 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2023-01-19
+
+- Fix no-std feature (some of the imports incorrectly used `std::` instead of `crate::maybestd::`)
+- Fix borsh-schema derives with `for` bounds
+- Implemented BorshSchema for HashSet
+- Add support for isize, usize types
+- Delete schema for char
+- Implement ser/de and schema for (T,)
+- Add clone impls to borsh schema types
+- Remove unnecessary trait bounds requirements for array
 - *BREAKING CHANGE*: `BorshDeserialize` now works by receiving an `&mut std::io::Read`
   instead of a `&mut &[u8]`. This is a breaking change for code that provides custom 
   implementations of `BorshDeserialize`; there is no impact on code that uses only the
   derive macro.
 - Added `BorshDeserialize::try_from_reader` and `BorshDeserialize::deserialize_reader`.
+- Upgrade hashbrown version to be `>=0.11,<0.14` to allow wider range of versions.
 
 ## [0.9.3] - 2022-02-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ members = [
 
 [workspace.metadata.workspaces]
 # shared version of all public crates in the workspace
-version = "0.9.3"
+version = "0.10.0"
 exclude = [ "fuzz/*", "benchmarks" ]

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/generate_schema_schema.rs"
 
 [dependencies]
 borsh-derive = { path = "../borsh-derive" }
-hashbrown = "0.13"
+hashbrown = ">=0.11,<0.14"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
@miraclx Do I understand correctly that all I need to do is to bump the version in Cargo.toml and make sure that CHANGELOG is up-to-date?