### PR TITLE
chore: Updated Minimum Supported Rust Version to 1.55 (manually confirmed with cargo-msrv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Borsh in Rust &emsp; [![Latest Version]][crates.io] [![borsh: rustc 1.40+]][Rust 1.40] [![License Apache-2.0 badge]][License Apache-2.0] [![License MIT badge]][License MIT]
+# Borsh in Rust &emsp; [![Latest Version]][crates.io] [![borsh: rustc 1.55+]][Rust 1.55] [![License Apache-2.0 badge]][License Apache-2.0] [![License MIT badge]][License MIT]
 
 [Borsh]: https://borsh.io
 [Latest Version]: https://img.shields.io/crates/v/borsh.svg
 [crates.io]: https://crates.io/crates/borsh
-[borsh: rustc 1.40+]: https://img.shields.io/badge/rustc-1.40+-lightgray.svg
-[Rust 1.40]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html
+[borsh: rustc 1.55+]: https://img.shields.io/badge/rustc-1.55+-lightgray.svg
+[Rust 1.55]: https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html
 [License Apache-2.0 badge]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [License Apache-2.0]: https://opensource.org/licenses/Apache-2.0
 [License MIT badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
The README was out of date, as borsh is now using const generics and MaybeUninit that were stabilized after Rust 1.40. I used the following commands to find out the minimum supported Rust version:

```
cargo +nightly update -Z minimal-versions
cargo update -p syn@1.0.0
cargo-msrv
```

Using Rust 1.54.0, compilation still fails:

```
    Checking borsh v0.0.0 (/home/near/borsh-rs/borsh)
error[E0658]: use of unstable library feature 'maybe_uninit_extra'
   --> borsh/src/de/mod.rs:595:26
    |
595 |                     elem.write(f()?);
    |                          ^^^^^
    |
    = note: see issue #63567 <https://github.com/rust-lang/rust/issues/63567> for more information

error: aborting due to previous error
```

Borsh compiles just fine starting with Rust version 1.55