### PR TITLE
Add optional BSON object id support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add optional BSON object id support
+
 ## [0.10.3] - 2022-03-22
 
 - Add optional bytes/bytesmut support
@@ -31,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add clone impls to borsh schema types
 - Remove unnecessary trait bounds requirements for array
 - *BREAKING CHANGE*: `BorshDeserialize` now works by receiving an `&mut std::io::Read`
-  instead of a `&mut &[u8]`. This is a breaking change for code that provides custom 
+  instead of a `&mut &[u8]`. This is a breaking change for code that provides custom
   implementations of `BorshDeserialize`; there is no impact on code that uses only the
   derive macro.
 - Added `BorshDeserialize::try_from_reader` and `BorshDeserialize::deserialize_reader`.

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -24,11 +24,13 @@ path = "src/generate_schema_schema.rs"
 borsh-derive = { path = "../borsh-derive" }
 hashbrown = ">=0.11,<0.14"
 bytes = { version = "1", optional = true }
+bson = { version = "2", optional = true }
 
 [dev-dependencies]
 bytes = "1"
-# Enable the "bytes" feature in integ tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-1464060655
-borsh = { path = ".", features = ["bytes"] }
+bson = "2"
+# Enable the "bytes" and "bson" features in integ tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-1464060655
+borsh = { path = ".", features = ["bytes", "bson"] }
 
 [features]
 default = ["std"]

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -425,6 +425,16 @@ impl BorshDeserialize for bytes::BytesMut {
     }
 }
 
+#[cfg(any(test, feature = "bson"))]
+impl BorshDeserialize for bson::oid::ObjectId {
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        let mut buf = [0u8; 12];
+        reader.read_exact(&mut buf)?;
+        Ok(bson::oid::ObjectId::from_bytes(buf))
+    }
+}
+
 impl<T> BorshDeserialize for Cow<'_, T>
 where
     T: ToOwned + ?Sized,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -287,6 +287,14 @@ impl BorshSerialize for bytes::BytesMut {
     }
 }
 
+#[cfg(any(test, feature = "bson"))]
+impl BorshSerialize for bson::oid::ObjectId {
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.bytes().serialize(writer)
+    }
+}
+
 impl<T> BorshSerialize for VecDeque<T>
 where
     T: BorshSerialize,

--- a/borsh/tests/test_bson_object_ids.rs
+++ b/borsh/tests/test_bson_object_ids.rs
@@ -1,0 +1,19 @@
+#![allow(clippy::float_cmp)]
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use bson::oid::ObjectId;
+
+#[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
+struct StructWithObjectId(i32, ObjectId, u8);
+
+#[test]
+fn test_object_id() {
+    let obj = StructWithObjectId(
+        123,
+        ObjectId::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        33,
+    );
+    let serialized = obj.try_to_vec().unwrap();
+    let deserialized: StructWithObjectId = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    assert_eq!(obj, deserialized);
+}


### PR DESCRIPTION
Hey!

As a MongoDB user I would be happy to have a support for its [ObjectId](https://www.mongodb.com/docs/manual/reference/bson-types/#std-label-objectid) data type. It's just a dozen of bytes.