### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/borsh-derive-internal/Cargo.toml
+++ b/borsh-derive-internal/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 categories = ["encoding", "network-programming"]
 repository = "https://github.com/nearprotocol/borsh"
-homepage = "http://borsh.io"
+homepage = "https://borsh.io"
 description = """
 Binary Object Representation Serializer for Hashing
 """

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 categories = ["encoding", "network-programming"]
 repository = "https://github.com/nearprotocol/borsh"
-homepage = "http://borsh.io"
+homepage = "https://borsh.io"
 description = """
 Binary Object Representation Serializer for Hashing
 """

--- a/borsh-schema-derive-internal/Cargo.toml
+++ b/borsh-schema-derive-internal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 categories = ["encoding", "network-programming"]
 repository = "https://github.com/nearprotocol/borsh"
-homepage = "http://borsh.io"
+homepage = "https://borsh.io"
 description = """
 Schema Generator for Borsh
 """

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 categories = ["encoding", "network-programming"]
 repository = "https://github.com/near/borsh-rs"
-homepage = "http://borsh.io"
+homepage = "https://borsh.io"
 description = """
 Binary Object Representation Serializer for Hashing
 """


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `borsh-derive/Cargo.toml`:
 - `http://borsh.io` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `borsh-schema-derive-internal/Cargo.toml`:
 - `http://borsh.io` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `borsh-derive-internal/Cargo.toml`:
 - `http://borsh.io` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

In file `borsh/Cargo.toml`:
 - `http://borsh.io` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

