### PR TITLE
Add top-level from_slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ strict [specification](https://github.com/near/borsh#specification).
 ## Example
 
 ```rust
-use borsh::{BorshSerialize, BorshDeserialize};
+use borsh::{BorshSerialize, BorshDeserialize, from_slice};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 struct A {
@@ -34,7 +34,7 @@ fn test_simple_struct() {
         y: "liber primus".to_string(),
     };
     let encoded_a = a.try_to_vec().unwrap();
-    let decoded_a = A::try_from_slice(&encoded_a).unwrap();
+    let decoded_a = from_slice::<A>(&encoded_a).unwrap();
     assert_eq!(a, decoded_a);
 }
 ```

--- a/benchmarks/benches/bench.rs
+++ b/benchmarks/benches/bench.rs
@@ -1,5 +1,5 @@
 use benchmarks::{Account, Block, BlockHeader, Generate, SignedTransaction};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use rand::SeedableRng;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use speedy::Endianness;
@@ -123,7 +123,7 @@ where
             BenchmarkId::new("borsh", benchmark_param_display.clone()),
             borsh_data,
             |b, d| {
-                b.iter(|| T::try_from_slice(d).unwrap());
+                b.iter(|| from_slice::<T>(d).unwrap());
             },
         );
         group.bench_with_input(

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/generate_schema_schema.rs"
 
 [dependencies]
 borsh-derive = { path = "../borsh-derive" }
+hashbrown = ">=0.11,<0.14"
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }
 

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/generate_schema_schema.rs"
 
 [dependencies]
 borsh-derive = { path = "../borsh-derive" }
-hashbrown = ">=0.11,<0.14"
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }
 

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -816,7 +816,6 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
     Ok(object)
 }
 
-// Add documentation with examples.
 /// Deserializes an object from a reader.
 /// # Example
 /// ```

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -25,11 +25,13 @@ use crate::maybestd::{rc::Rc, sync::Arc};
 
 mod hint;
 
-const ERROR_NOT_ALL_BYTES_READ: &str = "Not all bytes read";
-const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
-const ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_ISIZE: &str = "Overflow on machine with 32 bit isize";
-const ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_USIZE: &str = "Overflow on machine with 32 bit usize";
-const ERROR_INVALID_ZERO_VALUE: &str = "Expected a non-zero value";
+pub const ERROR_NOT_ALL_BYTES_READ: &str = "Not all bytes read";
+pub const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
+pub const ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_ISIZE: &str =
+    "Overflow on machine with 32 bit isize";
+pub const ERROR_OVERFLOW_ON_MACHINE_WITH_32_BIT_USIZE: &str =
+    "Overflow on machine with 32 bit usize";
+pub const ERROR_INVALID_ZERO_VALUE: &str = "Expected a non-zero value";
 
 /// A data-structure that can be de-serialized from binary format by NBOR.
 pub trait BorshDeserialize: Sized {
@@ -42,6 +44,10 @@ pub trait BorshDeserialize: Sized {
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self>;
 
     /// Deserialize this instance from a slice of bytes.
+    #[deprecated(
+        since = "1.0.0",
+        note = "please use `borsh::from_slice` new function instead"
+    )]
     fn try_from_slice(v: &[u8]) -> Result<Self> {
         let mut v_mut = v;
         let result = Self::deserialize(&mut v_mut)?;

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -828,7 +828,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// }
 /// let original = MyStruct { a: 10, b: vec![1, 2, 3] };
 /// let encoded = original.try_to_vec().unwrap();
-/// let mut cursor = Cursor::new(encoded).as_slice();
+/// let mut cursor = Cursor::new(encoded.as_slice());
 /// let decoded = from_reader::<_, MyStruct>(&mut cursor).unwrap();
 /// assert_eq!(original, decoded);
 /// ```

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -820,7 +820,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// # Example
 /// ```
 /// use borsh::{BorshDeserialize, BorshSerialize, from_reader};
-/// use std::io::Cursor;
+///
 /// #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 /// struct MyStruct {
 ///   a: u64,
@@ -828,8 +828,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// }
 /// let original = MyStruct { a: 10, b: vec![1, 2, 3] };
 /// let encoded = original.try_to_vec().unwrap();
-/// let mut cursor = Cursor::new(encoded.as_slice());
-/// let decoded = from_reader::<_, MyStruct>(&mut cursor).unwrap();
+/// let decoded = from_reader::<_, MyStruct>(&mut encoded.as_slice()).unwrap();
 /// assert_eq!(original, decoded);
 /// ```
 pub fn from_reader<R: Read, T: BorshDeserialize>(reader: &mut R) -> Result<T> {

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -88,6 +88,7 @@ pub trait EnumExt: BorshDeserialize {
     /// ```
     /// use borsh::BorshDeserialize;
     /// use borsh::de::EnumExt as _;
+    /// use borsh::from_slice;
     ///
     /// #[derive(Debug, PartialEq, Eq, BorshDeserialize)]
     /// enum MyEnum {
@@ -117,12 +118,12 @@ pub trait EnumExt: BorshDeserialize {
     /// }
     ///
     /// let data = b"\0";
-    /// assert_eq!(MyEnum::Zero, MyEnum::try_from_slice(&data[..]).unwrap());
-    /// assert_eq!(MyEnum::Zero, OneOrZero::try_from_slice(&data[..]).unwrap().0);
+    /// assert_eq!(MyEnum::Zero, from_slice::<MyEnum>(&data[..]).unwrap());
+    /// assert_eq!(MyEnum::Zero, from_slice::<OneOrZero>(&data[..]).unwrap().0);
     ///
     /// let data = b"\x02\0\0\0\0";
-    /// assert_eq!(MyEnum::Many(Vec::new()), MyEnum::try_from_slice(&data[..]).unwrap());
-    /// assert!(OneOrZero::try_from_slice(&data[..]).is_err());
+    /// assert_eq!(MyEnum::Many(Vec::new()), from_slice::<MyEnum>(&data[..]).unwrap());
+    /// assert!(from_slice::<OneOrZero>(&data[..]).is_err());
     /// ```
     fn deserialize_variant<R: Read>(reader: &mut R, tag: u8) -> Result<Self>;
 }

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -828,7 +828,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// }
 /// let original = MyStruct { a: 10, b: vec![1, 2, 3] };
 /// let encoded = original.try_to_vec().unwrap();
-/// let mut cursor = Cursor::new(encoded);
+/// let mut cursor = Cursor::new(encoded).as_slice();
 /// let decoded = from_reader::<_, MyStruct>(&mut cursor).unwrap();
 /// assert_eq!(original, decoded);
 /// ```

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -12,9 +12,10 @@ pub mod schema;
 pub mod schema_helpers;
 pub mod ser;
 
+pub use de::from_slice;
 pub use de::BorshDeserialize;
 pub use schema::BorshSchema;
-pub use schema_helpers::{from_slice, try_from_slice_with_schema, try_to_vec_with_schema};
+pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
 pub use ser::helpers::{to_vec, to_writer};
 pub use ser::BorshSerialize;
 

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -42,6 +42,7 @@ pub mod maybestd {
 
     pub mod collections {
         pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+        pub use hashbrown::*;
     }
 
     pub mod io {

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -12,8 +12,8 @@ pub mod schema;
 pub mod schema_helpers;
 pub mod ser;
 
-pub use de::from_slice;
 pub use de::BorshDeserialize;
+pub use de::{from_reader, from_slice};
 pub use schema::BorshSchema;
 pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
 pub use ser::helpers::{to_vec, to_writer};

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -14,7 +14,7 @@ pub mod ser;
 
 pub use de::BorshDeserialize;
 pub use schema::BorshSchema;
-pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
+pub use schema_helpers::{from_slice, try_from_slice_with_schema, try_to_vec_with_schema};
 pub use ser::helpers::{to_vec, to_writer};
 pub use ser::BorshSerialize;
 
@@ -41,7 +41,6 @@ pub mod maybestd {
 
     pub mod collections {
         pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
-        pub use hashbrown::*;
     }
 
     pub mod io {

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -5,6 +5,7 @@ use crate::maybestd::{
 };
 use crate::schema::BorshSchemaContainer;
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
+
 /// Deserialize this instance from a slice of bytes, but assume that at the beginning we have
 /// bytes describing the schema of the type. We deserialize this schema and verify that it is
 /// correct.

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -1,38 +1,19 @@
+use crate::from_slice;
 use crate::maybestd::{
     io::{Error, ErrorKind, Result},
     vec::Vec,
 };
 use crate::schema::BorshSchemaContainer;
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
-
 /// Deserialize this instance from a slice of bytes, but assume that at the beginning we have
 /// bytes describing the schema of the type. We deserialize this schema and verify that it is
 /// correct.
 pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -> Result<T> {
-    let mut v_mut = v;
-    let (schema, object) = <(BorshSchemaContainer, T)>::deserialize(&mut v_mut)?;
-    if !v_mut.is_empty() {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            crate::de::ERROR_NOT_ALL_BYTES_READ,
-        ));
-    }
+    let (schema, object) = from_slice::<(BorshSchemaContainer, T)>(v)?;
     if T::schema_container() != schema {
         return Err(Error::new(
             ErrorKind::InvalidData,
             "Borsh schema does not match",
-        ));
-    }
-    Ok(object)
-}
-
-pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
-    let mut v_mut = v;
-    let object = T::deserialize(&mut v_mut)?;
-    if !v_mut.is_empty() {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            crate::de::ERROR_NOT_ALL_BYTES_READ,
         ));
     }
     Ok(object)

--- a/borsh/tests/smoke.rs
+++ b/borsh/tests/smoke.rs
@@ -1,13 +1,15 @@
 // Smoke tests that ensure that we don't accidentally remove top-level
 // re-exports in a minor release.
 
-use borsh::{self, BorshDeserialize};
+use borsh::{self, from_slice, try_from_slice_with_schema, BorshSchema};
 
 #[test]
 fn test_to_vec() {
     let value = 42u8;
-    let serialized = borsh::to_vec(&value).unwrap();
-    let deserialized = u8::try_from_slice(&serialized).unwrap();
+    let seriazeble = (<u8 as BorshSchema>::schema_container(), value);
+    let serialized = borsh::to_vec(&seriazeble).unwrap();
+    println!("serialized: {:?}", serialized);
+    let deserialized = try_from_slice_with_schema::<u8>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }
 
@@ -15,7 +17,8 @@ fn test_to_vec() {
 fn test_to_writer() {
     let value = 42u8;
     let mut serialized = vec![0; 1];
+    // serialized: [2, 0, 0, 0, 117, 56, 0, 0, 0, 0, 42]
     borsh::to_writer(&mut serialized[..], &value).unwrap();
-    let deserialized = u8::try_from_slice(&serialized).unwrap();
+    let deserialized = from_slice::<u8>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }

--- a/borsh/tests/test_arrays.rs
+++ b/borsh/tests/test_arrays.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::float_cmp)]
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 
 macro_rules! test_array {
     ($v: expr, $t: ty, $len: expr) => {
         let buf = $v.try_to_vec().unwrap();
-        let actual_v: [$t; $len] =
-            BorshDeserialize::try_from_slice(&buf).expect("failed to deserialize");
+        let actual_v: [$t; $len] = from_slice(&buf).expect("failed to deserialize");
         assert_eq!($v.len(), actual_v.len());
         #[allow(clippy::reversed_empty_ranges)]
         for i in 0..$len {
@@ -53,7 +52,7 @@ struct CustomStruct(u8);
 fn test_custom_struct_array() {
     let arr = [CustomStruct(0), CustomStruct(1), CustomStruct(2)];
     let serialized = arr.try_to_vec().unwrap();
-    let deserialized: [CustomStruct; 3] = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    let deserialized: [CustomStruct; 3] = from_slice(&serialized).unwrap();
     assert_eq!(arr, deserialized);
 }
 
@@ -61,6 +60,6 @@ fn test_custom_struct_array() {
 fn test_string_array() {
     let arr = ["0".to_string(), "1".to_string(), "2".to_string()];
     let serialized = arr.try_to_vec().unwrap();
-    let deserialized: [String; 3] = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    let deserialized: [String; 3] = from_slice(&serialized).unwrap();
     assert_eq!(arr, deserialized);
 }

--- a/borsh/tests/test_binary_heaps.rs
+++ b/borsh/tests/test_binary_heaps.rs
@@ -1,11 +1,10 @@
 use borsh::maybestd::collections::BinaryHeap;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 macro_rules! test_binary_heap {
     ($v: expr, $t: ty) => {
         let buf = $v.try_to_vec().unwrap();
-        let actual_v: BinaryHeap<$t> =
-            BorshDeserialize::try_from_slice(&buf).expect("failed to deserialize");
+        let actual_v: BinaryHeap<$t> = from_slice(&buf).expect("failed to deserialize");
         assert_eq!(actual_v.into_vec(), $v.into_vec());
     };
 }

--- a/borsh/tests/test_bson_object_ids.rs
+++ b/borsh/tests/test_bson_object_ids.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::float_cmp)]
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bson::oid::ObjectId;
 
 #[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
@@ -14,6 +14,6 @@ fn test_object_id() {
         33,
     );
     let serialized = obj.try_to_vec().unwrap();
-    let deserialized: StructWithObjectId = BorshDeserialize::try_from_slice(&serialized).unwrap();
+    let deserialized: StructWithObjectId = from_slice(&serialized).unwrap();
     assert_eq!(obj, deserialized);
 }

--- a/borsh/tests/test_custom_reader.rs
+++ b/borsh/tests/test_custom_reader.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_reader, BorshDeserialize, BorshSerialize};
 
 const ERROR_NOT_ALL_BYTES_READ: &str = "Not all bytes read";
 const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
@@ -63,7 +63,7 @@ fn test_custom_reader_with_too_much_data() {
         read_index: 0,
     };
     assert_eq!(
-        <Serializable as BorshDeserialize>::try_from_reader(&mut reader)
+        from_reader::<CustomReader, Serializable>(&mut reader)
             .unwrap_err()
             .to_string(),
         ERROR_NOT_ALL_BYTES_READ
@@ -120,7 +120,8 @@ impl borsh::maybestd::io::Read for CustomReaderThatDoesntFillSlices {
 #[test]
 fn test_custom_reader_that_fails_preserves_error_information() {
     let mut reader = CustomReaderThatFails;
-    let err = <Serializable as BorshDeserialize>::try_from_reader(&mut reader).unwrap_err();
+
+    let err = from_reader::<CustomReaderThatFails, Serializable>(&mut reader).unwrap_err();
     assert_eq!(err.to_string(), "I don't like to run");
     assert_eq!(
         err.kind(),

--- a/borsh/tests/test_generic_struct.rs
+++ b/borsh/tests/test_generic_struct.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 struct A<T, F, G> {
@@ -29,6 +29,6 @@ fn test_generic_struct() {
         d: [0, 1, 2, 3, 4],
     };
     let data = a.try_to_vec().unwrap();
-    let actual_a = A::<String, u64, String>::try_from_slice(&data).unwrap();
+    let actual_a = from_slice::<A<String, u64, String>>(&data).unwrap();
     assert_eq!(a, actual_a);
 }

--- a/borsh/tests/test_hash_map.rs
+++ b/borsh/tests/test_hash_map.rs
@@ -4,7 +4,7 @@ use core::hash::BuildHasher;
 use std::collections::hash_map::{DefaultHasher, RandomState};
 
 use borsh::maybestd::collections::HashMap;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 #[test]
 fn test_default_hashmap() {
@@ -13,7 +13,7 @@ fn test_default_hashmap() {
     map.insert("one".to_string(), "two".to_string());
 
     let data = map.try_to_vec().unwrap();
-    let actual_map = HashMap::<String, String>::try_from_slice(&data).unwrap();
+    let actual_map = from_slice::<HashMap<String, String>>(&data).unwrap();
     assert_eq!(map, actual_map);
 }
 
@@ -37,6 +37,6 @@ fn test_generic_hash_hashmap() {
     map.insert("one".to_string(), "two".to_string());
 
     let data = map.try_to_vec().unwrap();
-    let actual_map = HashMap::<String, String, NewHasher>::try_from_slice(&data).unwrap();
+    let actual_map = from_slice::<HashMap<String, String, NewHasher>>(&data).unwrap();
     assert_eq!(map, actual_map);
 }

--- a/borsh/tests/test_nonzero_integers.rs
+++ b/borsh/tests/test_nonzero_integers.rs
@@ -1,32 +1,32 @@
-use borsh::BorshDeserialize;
+use borsh::from_slice;
 use std::num::*;
 
 #[test]
 fn test_nonzero_integer_u8() {
     let bytes = &[1];
-    assert_eq!(NonZeroU8::try_from_slice(bytes).unwrap().get(), 1);
+    assert_eq!(from_slice::<NonZeroU8>(bytes).unwrap().get(), 1);
 }
 
 #[test]
 fn test_nonzero_integer_u32() {
     let bytes = &[255, 0, 0, 0];
-    assert_eq!(NonZeroU32::try_from_slice(bytes).unwrap().get(), 255);
+    assert_eq!(from_slice::<NonZeroU32>(bytes).unwrap().get(), 255);
 }
 
 #[test]
 fn test_nonzero_integer_usize() {
     let bytes = &[1, 1, 0, 0, 0, 0, 0, 0];
-    assert_eq!(NonZeroUsize::try_from_slice(bytes).unwrap().get(), 257);
+    assert_eq!(from_slice::<NonZeroUsize>(bytes).unwrap().get(), 257);
 }
 
 #[test]
 fn test_nonzero_integer_i64() {
     let bytes = &[255; 8];
-    assert_eq!(NonZeroI64::try_from_slice(bytes).unwrap().get(), -1);
+    assert_eq!(from_slice::<NonZeroI64>(bytes).unwrap().get(), -1);
 }
 
 #[test]
 fn test_nonzero_integer_i16b() {
     let bytes = &[0, 0b1000_0000];
-    assert_eq!(NonZeroI16::try_from_slice(bytes).unwrap().get(), i16::MIN);
+    assert_eq!(from_slice::<NonZeroI16>(bytes).unwrap().get(), i16::MIN);
 }

--- a/borsh/tests/test_primitives.rs
+++ b/borsh/tests/test_primitives.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 macro_rules! test_primitive {
     ($test_name: ident, $v: expr, $t: ty) => {
@@ -6,7 +6,7 @@ macro_rules! test_primitive {
         fn $test_name() {
             let expected: $t = $v;
             let buf = expected.try_to_vec().unwrap();
-            let actual = <$t>::try_from_slice(&buf).expect("failed to deserialize");
+            let actual = from_slice::<$t>(&buf).expect("failed to deserialize");
             assert_eq!(actual, expected);
         }
     };

--- a/borsh/tests/test_rc.rs
+++ b/borsh/tests/test_rc.rs
@@ -2,13 +2,13 @@
 
 use borsh::maybestd::rc::Rc;
 use borsh::maybestd::sync::Arc;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 #[test]
 fn test_rc_roundtrip() {
     let value = Rc::new(8u8);
     let serialized = value.try_to_vec().unwrap();
-    let deserialized = Rc::<u8>::try_from_slice(&serialized).unwrap();
+    let deserialized = from_slice::<Rc<u8>>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }
 
@@ -16,6 +16,6 @@ fn test_rc_roundtrip() {
 fn test_arc_roundtrip() {
     let value = Arc::new(8u8);
     let serialized = value.try_to_vec().unwrap();
-    let deserialized = Arc::<u8>::try_from_slice(&serialized).unwrap();
+    let deserialized = from_slice::<Arc<u8>>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }

--- a/borsh/tests/test_simple_structs.rs
+++ b/borsh/tests/test_simple_structs.rs
@@ -1,5 +1,5 @@
 use borsh::maybestd::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytes::{Bytes, BytesMut};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
@@ -97,17 +97,14 @@ fn test_discriminant_serialization() {
 fn test_discriminant_deserialization() {
     let values = vec![X::A, X::B, X::C, X::D, X::E, X::F];
     for value in values {
-        assert_eq!(
-            <X as BorshDeserialize>::try_from_slice(&[value as u8]).unwrap(),
-            value,
-        );
+        assert_eq!(from_slice::<X>(&[value as u8]).unwrap(), value,);
     }
 }
 
 #[test]
 #[should_panic = "Unexpected variant tag: 2"]
 fn test_deserialize_invalid_discriminant() {
-    <X as BorshDeserialize>::try_from_slice(&[2]).unwrap();
+    from_slice::<X>(&[2]).unwrap();
 }
 
 #[test]
@@ -154,7 +151,7 @@ fn test_simple_struct() {
     let encoded_ref_a = e.try_to_vec().unwrap();
     assert_eq!(encoded_ref_a, encoded_a);
 
-    let decoded_a = A::try_from_slice(&encoded_a).unwrap();
+    let decoded_a = from_slice::<A>(&encoded_a).unwrap();
     let expected_a = A {
         x: 1,
         b: B {
@@ -192,7 +189,7 @@ fn test_simple_struct() {
 
     let f1 = F1 { aa: &[&a, &a] };
     let encoded_f1 = f1.try_to_vec().unwrap();
-    let decoded_f2 = F2::try_from_slice(&encoded_f1).unwrap();
+    let decoded_f2 = from_slice::<F2>(&encoded_f1).unwrap();
     assert_eq!(decoded_f2.aa.len(), 2);
     assert!(decoded_f2.aa.iter().all(|f2_a| f2_a == &expected_a));
 }

--- a/borsh/tests/test_strings.rs
+++ b/borsh/tests/test_strings.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 macro_rules! test_string {
     ($test_name: ident, $str: expr) => {
@@ -6,7 +6,7 @@ macro_rules! test_string {
         fn $test_name() {
             let s = $str.to_string();
             let buf = s.try_to_vec().unwrap();
-            let actual_s = <String>::try_from_slice(&buf).expect("failed to deserialize a string");
+            let actual_s = from_slice::<String>(&buf).expect("failed to deserialize a string");
             assert_eq!(actual_s, s);
         }
     };

--- a/borsh/tests/test_tuple.rs
+++ b/borsh/tests/test_tuple.rs
@@ -1,9 +1,9 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 #[test]
 fn test_unary_tuple() {
     let expected = (true,);
     let buf = expected.try_to_vec().unwrap();
-    let actual = <(bool,)>::try_from_slice(&buf).expect("failed to deserialize");
+    let actual = from_slice::<(bool,)>(&buf).expect("failed to deserialize");
     assert_eq!(actual, expected);
 }

--- a/borsh/tests/test_vecs.rs
+++ b/borsh/tests/test_vecs.rs
@@ -1,10 +1,9 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, BorshSerialize};
 
 macro_rules! test_vec {
     ($v: expr, $t: ty) => {
         let buf = $v.try_to_vec().unwrap();
-        let actual_v: Vec<$t> =
-            BorshDeserialize::try_from_slice(&buf).expect("failed to deserialize");
+        let actual_v: Vec<$t> = from_slice(&buf).expect("failed to deserialize");
         assert_eq!(actual_v, $v);
     };
 }

--- a/borsh/tests/test_zero_size.rs
+++ b/borsh/tests/test_zero_size.rs
@@ -1,3 +1,4 @@
+use borsh::from_slice;
 use borsh::BorshDeserialize;
 
 #[derive(BorshDeserialize, PartialEq, Debug)]
@@ -6,6 +7,6 @@ struct A;
 #[test]
 fn test_deserialize_vector_to_many_zero_size_struct() {
     let v = [0u8, 0u8, 0u8, 64u8];
-    let a = Vec::<A>::try_from_slice(&v).unwrap();
+    let a = from_slice::<Vec<A>>(&v).unwrap();
     assert_eq!(A {}, a[usize::pow(2, 30) - 1])
 }


### PR DESCRIPTION
Addresses several items from #51:

* [x] deprecate `BorshDeserialize::try_from_slice` in favor of `borsh::from_slice` top-level function ( 😡 a lot of churn with this one)