### PR TITLE
fix: no-std tests did not run due to dev-dependencies re-enabling std feature

### DIFF
--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -30,7 +30,7 @@ bson = { version = "2", optional = true }
 bytes = "1"
 bson = "2"
 # Enable the "bytes" and "bson" features in integ tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-1464060655
-borsh = { path = ".", features = ["bytes", "bson"] }
+borsh = { path = ".", default_features = false, features = ["bytes", "bson"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
It degraded with this PR: #132.

Without this fix, `cargo test -p borsh --no-default-features` would still run tests with `std` and thus you could [break no-std support unnoticeably](https://github.com/near/borsh-rs/pull/142#discussion_r1211525116).