### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1](https://github.com/near/borsh-rs/compare/borsh-v0.11.0...borsh-v1.0.0-alpha.1) - 2023-08-07
+
+### Bug Fixes
+
+- Unused fields warn, fields for inner structs of derived BorshSchema method (#172)
+- #[borsh_skip] on field of struct enum variant (BorshSerialize) (#174)
+- Filter out foreign attributes in `BorshSchema` derive for enum (#177)
+
+### Documentation
+
+- Create a brief documentation of crate's features (#159)
+- Mention `schema` feature in doc.rs (#166)
+
+### Features
+
+- Forbid Vectors of Zero-sized types from de-/serialization to resolve the RUSTSEC-2023-0033 (#145)
+- Add top-level `from_slice` and `from_reader` helper functions to make the API nicer (#142)
+- [**breaking**] Add `#[borsh(use_discriminant = <bool>)]` attribute that changes enum discriminant de- and serialization behavior
+- [**breaking**] Remove `BinaryHeap` support (#161)
+- Sets/maps benches for reference point (#164)
+- Enforce canonicity on `HashSet/BTreeSet/HashMap/BTreeMap` (#162)
+- [**breaking**] Support recursive structures! (#178)
+  - `BorshSerialize`, `BorshDeserialize`, `BorshSchema` derives may break
+  - derives may require patching bounds with `#[borsh(bound(..))]` / `#[borsh(schema(params = ...))]`
+- Bounds for ser/de derive and schema_params for schema derive attributes (#180)
+- Derive attribute for 3rd party structs/enums as fields (#182)
+
+### Miscellaneous Tasks
+
+- Bump proc-macro-crate versions  (#149)
+- Add tests job for MSRV (1.65.0) (#151)
+- [**breaking**] Hide maybestd from public interface, despite it being technically available by new name of __maybestd (#153)
+- Fix broken reference-style link in minimum supported version badge (#154)
+- Remove a bunch of clippy-related TODOs (uninlined_format_args) (#156)
+- Simpler bounds on Rc/Arc impls (#167)
+- Invited @dj8yfo to CODEOWNERS (#169)
+- [**breaking**] Replace ErrorKind::InvalidInput with ErrorKind::InvalidData as per original std::io meaning (#170)
+
+### Refactor
+
+- [**breaking**] Make `hashbrown` dependency optional, `hashbrown` feature (#155)
+- [**breaking**] `BorshSchemaContainer` fields non-pub, `HashMap` -> `BTreeMap` in schema everywhere (#165)
+- [**breaking**] Move derive under #[cfg(feature = "derive")] (#168)
+- Introduce `__private` module with macro runtime (#171)
+- [**breaking**] Unsplit and removal of *-internal crates (#185)
+  - `borsh-schema-derive-internal` and `borsh-derive-internal` crates won't be published anymore
+
+### Testing
+
+- Add `insta` snapshots to borsh/tests (#157)
+- `insta` tests for prettified `TokenStream`-s in `borsh*derive-internal` (#176)
+
+### Ci
+
+- Only release-plz after other checks pass
+
 ## [0.11.0](https://github.com/near/borsh-rs/compare/borsh-v0.10.3...borsh-v0.11.0) - 2023-05-31
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "0.11.0"
+version = "1.0.0-alpha.1"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["std", "derive", "schema"]
 cfg_aliases = "0.1.0"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "0.11.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.1", optional = true }
 hashbrown = { version = ">=0.11,<0.14", optional = true }
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 0.11.0 -> 1.0.0-alpha.1 
* `borsh-derive`: 0.11.0 -> 1.0.0-alpha.1
* `borsh-derive-internal`: 0.11.0 -> 1.0.0-alpha.1 
* `borsh-schema-derive-internal`: 0.11.0 -> 1.0.0-alpha.1 

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.0.0-alpha.1](https://github.com/near/borsh-rs/compare/borsh-v0.11.0...borsh-v1.0.0-alpha.1) - 2023-08-07

### Bug Fixes

- Unused fields warn, fields for inner structs of derived BorshSchema method (#172)
- #[borsh_skip] on field of struct enum variant (BorshSerialize) (#174)
- Filter out foreign attributes in `BorshSchema` derive for enum (#177)

### Documentation

- Create a brief documentation of crate's features (#159)
- Mention `schema` feature in doc.rs (#166)

### Features

- Forbid Vectors of Zero-sized types from de-/serialization to resolve the RUSTSEC-2023-0033 (#145)
- Add top-level `from_slice` and `from_reader` helper functions to make the API nicer (#142)
- [**breaking**] Add `#[borsh(use_discriminant = <bool>)]` attribute that changes enum discriminant de- and serialization behavior
- [**breaking**] Remove `BinaryHeap` support (#161)
- Sets/maps benches for reference point (#164)
- Enforce canonicity on `HashSet/BTreeSet/HashMap/BTreeMap` (#162)
- [**breaking**] Support recursive structures! (#178)
  - `BorshSerialize`, `BorshDeserialize`, `BorshSchema` derives may break
  - derives may require patching bounds with `#[borsh(bound(..))]` / `#[borsh(schema(params = ...))]`
- Bounds for ser/de derive and schema_params for schema derive attributes (#180)
- Derive attribute for 3rd party structs/enums as fields (#182)

### Miscellaneous Tasks

- Bump proc-macro-crate versions  (#149)
- Add tests job for MSRV (1.65.0) (#151)
- [**breaking**] Hide maybestd from public interface, despite it being technically available by new name of __maybestd (#153)
- Fix broken reference-style link in minimum supported version badge (#154)
- Remove a bunch of clippy-related TODOs (uninlined_format_args) (#156)
- Simpler bounds on Rc/Arc impls (#167)
- Invited @dj8yfo to CODEOWNERS (#169)
- [**breaking**] Replace ErrorKind::InvalidInput with ErrorKind::InvalidData as per original std::io meaning (#170)

### Refactor

- [**breaking**] Make `hashbrown` dependency optional, `hashbrown` feature (#155)
- [**breaking**] `BorshSchemaContainer` fields non-pub, `HashMap` -> `BTreeMap` in schema everywhere (#165)
- [**breaking**] Move derive under #[cfg(feature = "derive")] (#168)
- Introduce `__private` module with macro runtime (#171)
- [**breaking**] Unsplit and removal of *-internal crates (#185)
  - `borsh-schema-derive-internal` and `borsh-derive-internal` crates won't be published anymore

### Testing

- Add `insta` snapshots to borsh/tests (#157)
- `insta` tests for prettified `TokenStream`-s in `borsh*derive-internal` (#176)

### Ci

- Only release-plz after other checks pass


</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/) and semi-automatically with @dj8yfo.