### PR TITLE
chore(doc)!: hide maybestd from public interface

### DIFF
--- a/borsh-derive-internal/src/enum_de.rs
+++ b/borsh-derive-internal/src/enum_de.rs
@@ -85,22 +85,22 @@ pub fn enum_de(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
 
     Ok(quote! {
         impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-            fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+            fn deserialize_reader<R: borsh::__maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__maybestd::io::Error> {
                 let tag = <u8 as #cratename::de::BorshDeserialize>::deserialize_reader(reader)?;
                 <Self as #cratename::de::EnumExt>::deserialize_variant(reader, tag)
             }
         }
 
         impl #impl_generics #cratename::de::EnumExt for #name #ty_generics #where_clause {
-            fn deserialize_variant<R: borsh::maybestd::io::Read>(
+            fn deserialize_variant<R: borsh::__maybestd::io::Read>(
                 reader: &mut R,
                 variant_tag: u8,
-            ) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+            ) -> ::core::result::Result<Self, #cratename::__maybestd::io::Error> {
                 let mut return_value =
                     #variant_arms {
-                    return Err(#cratename::maybestd::io::Error::new(
-                        #cratename::maybestd::io::ErrorKind::InvalidInput,
-                        #cratename::maybestd::format!("Unexpected variant tag: {:?}", variant_tag),
+                    return Err(#cratename::__maybestd::io::Error::new(
+                        #cratename::__maybestd::io::ErrorKind::InvalidInput,
+                        #cratename::__maybestd::format!("Unexpected variant tag: {:?}", variant_tag),
                     ))
                 };
                 #init

--- a/borsh-derive-internal/src/enum_ser.rs
+++ b/borsh-derive-internal/src/enum_ser.rs
@@ -95,7 +95,7 @@ pub fn enum_ser(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2>
     }
     Ok(quote! {
         impl #impl_generics #cratename::ser::BorshSerialize for #name #ty_generics #where_clause {
-            fn serialize<W: #cratename::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::maybestd::io::Error> {
+            fn serialize<W: #cratename::__maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::__maybestd::io::Error> {
                 let variant_idx: u8 = match self {
                     #variant_idx_body
                 };

--- a/borsh-derive-internal/src/struct_de.rs
+++ b/borsh-derive-internal/src/struct_de.rs
@@ -64,7 +64,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
     if let Some(method_ident) = init_method {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::__maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__maybestd::io::Error> {
                     let mut return_value = #return_value;
                     return_value.#method_ident();
                     Ok(return_value)
@@ -74,7 +74,7 @@ pub fn struct_de(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStrea
     } else {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::maybestd::io::Error> {
+                fn deserialize_reader<R: borsh::__maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__maybestd::io::Error> {
                     Ok(#return_value)
                 }
             }

--- a/borsh-derive-internal/src/struct_ser.rs
+++ b/borsh-derive-internal/src/struct_ser.rs
@@ -54,7 +54,7 @@ pub fn struct_ser(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStre
     }
     Ok(quote! {
         impl #impl_generics #cratename::ser::BorshSerialize for #name #ty_generics #where_clause {
-            fn serialize<W: #cratename::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::maybestd::io::Error> {
+            fn serialize<W: #cratename::__maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::__maybestd::io::Error> {
                 #body
                 Ok(())
             }
@@ -88,7 +88,7 @@ mod tests {
                 u64: borsh::ser::BorshSerialize,
                 String: borsh::ser::BorshSerialize
             {
-                fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+                fn serialize<W: borsh::__maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::__maybestd::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())
@@ -114,7 +114,7 @@ mod tests {
                 HashMap<K, V>: borsh::ser::BorshSerialize,
                 String: borsh::ser::BorshSerialize
             {
-                fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+                fn serialize<W: borsh::__maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::__maybestd::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())
@@ -141,7 +141,7 @@ mod tests {
                 HashMap<K, V>: borsh::ser::BorshSerialize,
                 String: borsh::ser::BorshSerialize
             {
-                fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+                fn serialize<W: borsh::__maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), borsh::__maybestd::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())

--- a/borsh-schema-derive-internal/src/enum_schema.rs
+++ b/borsh-schema-derive-internal/src/enum_schema.rs
@@ -108,10 +108,10 @@ pub fn process_enum(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStre
     }
 
     let type_definitions = quote! {
-        fn add_definitions_recursively(definitions: &mut #cratename::maybestd::collections::HashMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
+        fn add_definitions_recursively(definitions: &mut #cratename::__maybestd::collections::HashMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
             #anonymous_defs
             #add_recursive_defs
-            let variants = #cratename::maybestd::vec![#(#variants_defs),*];
+            let variants = #cratename::__maybestd::vec![#(#variants_defs),*];
             let definition = #cratename::schema::Definition::Enum{variants};
             Self::add_definition(Self::declaration(), definition, definitions);
         }
@@ -153,7 +153,7 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -164,7 +164,7 @@ mod tests {
                     struct AEggs;
                     <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
                     <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-                    let variants = borsh::maybestd::vec![
+                    let variants = borsh::__maybestd::vec![
                         ("Bacon".to_string(), <ABacon>::declaration()),
                         ("Eggs".to_string(), <AEggs>::declaration())
                     ];
@@ -191,7 +191,7 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -199,7 +199,7 @@ mod tests {
                     #[derive(borsh :: BorshSchema)]
                     struct ABacon;
                     <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-                    let variants = borsh::maybestd::vec![("Bacon".to_string(), <ABacon>::declaration())];
+                    let variants = borsh::__maybestd::vec![("Bacon".to_string(), <ABacon>::declaration())];
                     let definition = borsh::schema::Definition::Enum { variants };
                     Self::add_definition(Self::declaration(), definition, definitions);
                 }
@@ -226,7 +226,7 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -246,7 +246,7 @@ mod tests {
                     <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
                     <ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
                     <ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
-                    let variants = borsh::maybestd::vec![
+                    let variants = borsh::__maybestd::vec![
                         ("Bacon".to_string(), <ABacon>::declaration()),
                         ("Eggs".to_string(), <AEggs>::declaration()),
                         ("Salad".to_string(), <ASalad>::declaration()),
@@ -279,11 +279,11 @@ mod tests {
                 W: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<C>::declaration(), <W>::declaration()];
+                    let params = borsh::__maybestd::vec![<C>::declaration(), <W>::declaration()];
                     format!(r#"{}<{}>"#, "A", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -310,7 +310,7 @@ mod tests {
                     <AEggs<C, W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
                     <ASalad<C, W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
                     <ASausage<C, W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-                    let variants = borsh::maybestd::vec![
+                    let variants = borsh::__maybestd::vec![
                         ("Bacon".to_string(), <ABacon<C, W> >::declaration()),
                         ("Eggs".to_string(), <AEggs<C, W> >::declaration()),
                         ("Salad".to_string(), <ASalad<C, W> >::declaration()),
@@ -352,11 +352,11 @@ mod tests {
                 B: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<A>::declaration(), <B>::declaration()];
+                    let params = borsh::__maybestd::vec![<A>::declaration(), <B>::declaration()];
                     format!(r#"{}<{}>"#, "Side", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -383,7 +383,7 @@ mod tests {
                     ;
                     <SideLeft<A, B> as borsh::BorshSchema >::add_definitions_recursively(definitions);
                     <SideRight<A, B> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-                    let variants = borsh::maybestd::vec![
+                    let variants = borsh::__maybestd::vec![
                         ("Left".to_string(), <SideLeft<A, B> >::declaration()),
                         ("Right".to_string(), <SideRight<A, B> >::declaration())
                     ];

--- a/borsh-schema-derive-internal/src/helpers.rs
+++ b/borsh-schema-derive-internal/src/helpers.rs
@@ -31,7 +31,7 @@ pub fn declaration(
         }
     } else {
         quote! {
-                let params = #cratename::maybestd::vec![#(#declaration_params),*];
+                let params = #cratename::__maybestd::vec![#(#declaration_params),*];
                 format!(r#"{}<{}>"#, #ident_str, params.join(", "))
         }
     };

--- a/borsh-schema-derive-internal/src/struct_schema.rs
+++ b/borsh-schema-derive-internal/src/struct_schema.rs
@@ -37,7 +37,7 @@ pub fn process_struct(input: &ItemStruct, cratename: Ident) -> syn::Result<Token
             }
             if !fields_vec.is_empty() {
                 struct_fields = quote! {
-                    let fields = #cratename::schema::Fields::NamedFields(#cratename::maybestd::vec![#(#fields_vec),*]);
+                    let fields = #cratename::schema::Fields::NamedFields(#cratename::__maybestd::vec![#(#fields_vec),*]);
                 };
             }
         }
@@ -59,7 +59,7 @@ pub fn process_struct(input: &ItemStruct, cratename: Ident) -> syn::Result<Token
             }
             if !fields_vec.is_empty() {
                 struct_fields = quote! {
-                    let fields = #cratename::schema::Fields::UnnamedFields(#cratename::maybestd::vec![#(#fields_vec),*]);
+                    let fields = #cratename::schema::Fields::UnnamedFields(#cratename::__maybestd::vec![#(#fields_vec),*]);
                 };
             }
         }
@@ -73,7 +73,7 @@ pub fn process_struct(input: &ItemStruct, cratename: Ident) -> syn::Result<Token
     }
 
     let add_definitions_recursively = quote! {
-        fn add_definitions_recursively(definitions: &mut #cratename::maybestd::collections::HashMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
+        fn add_definitions_recursively(definitions: &mut #cratename::__maybestd::collections::HashMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
             #struct_fields
             let definition = #cratename::schema::Definition::Struct { fields };
             Self::add_definition(Self::declaration(), definition, definitions);
@@ -119,7 +119,7 @@ mod tests {
                 fn declaration() -> borsh::schema::Declaration {
                     "A".to_string()
                 }
-                fn add_definitions_recursively(definitions: &mut borsh::maybestd::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>) {
+                fn add_definitions_recursively(definitions: &mut borsh::__maybestd::collections::HashMap<borsh::schema::Declaration, borsh::schema::Definition>) {
                     let fields = borsh::schema::Fields::Empty;
                     let definition = borsh::schema::Definition::Struct { fields };
                     Self::add_definition(Self::declaration(), definition, definitions);
@@ -148,16 +148,16 @@ mod tests {
                 T: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<T>::declaration()];
+                    let params = borsh::__maybestd::vec![<T>::declaration()];
                     format!(r#"{}<{}>"#, "A", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![<T as borsh::BorshSchema>::declaration()]);
+                    let fields = borsh::schema::Fields::UnnamedFields(borsh::__maybestd::vec![<T as borsh::BorshSchema>::declaration()]);
                     let definition = borsh::schema::Definition::Struct { fields };
                     Self::add_definition(Self::declaration(), definition, definitions);
                     <T as borsh::BorshSchema>::add_definitions_recursively(definitions);
@@ -189,12 +189,12 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![
+                    let fields = borsh::schema::Fields::UnnamedFields(borsh::__maybestd::vec![
                         <u64 as borsh::BorshSchema>::declaration(),
                         <String as borsh::BorshSchema>::declaration()
                     ]);
@@ -229,17 +229,17 @@ mod tests {
                 V: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<K>::declaration(), <V>::declaration()];
+                    let params = borsh::__maybestd::vec![<K>::declaration(), <V>::declaration()];
                     format!(r#"{}<{}>"#, "A", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
                     let fields =
-                        borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![<K as borsh::BorshSchema>::declaration(), <V as borsh::BorshSchema>::declaration()]);
+                        borsh::schema::Fields::UnnamedFields(borsh::__maybestd::vec![<K as borsh::BorshSchema>::declaration(), <V as borsh::BorshSchema>::declaration()]);
                     let definition = borsh::schema::Definition::Struct { fields };
                     Self::add_definition(Self::declaration(), definition, definitions);
                     <K as borsh::BorshSchema>::add_definitions_recursively(definitions);
@@ -275,12 +275,12 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::NamedFields(borsh::maybestd::vec![
+                    let fields = borsh::schema::Fields::NamedFields(borsh::__maybestd::vec![
                         ("x".to_string(), <u64 as borsh::BorshSchema>::declaration()),
                         ("y".to_string(), <String as borsh::BorshSchema>::declaration())
                     ]);
@@ -318,16 +318,16 @@ mod tests {
                 String: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<K>::declaration(), <V>::declaration()];
+                    let params = borsh::__maybestd::vec![<K>::declaration(), <V>::declaration()];
                     format!(r#"{}<{}>"#, "A", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::NamedFields(borsh::maybestd::vec![
+                    let fields = borsh::schema::Fields::NamedFields(borsh::__maybestd::vec![
                         ("x".to_string(), <HashMap<K, V> as borsh::BorshSchema>::declaration()),
                         ("y".to_string(), <String as borsh::BorshSchema>::declaration())
                     ]);
@@ -369,16 +369,16 @@ mod tests {
                 String: borsh::BorshSchema
             {
                 fn declaration() -> borsh::schema::Declaration {
-                    let params = borsh::maybestd::vec![<K>::declaration(), <V>::declaration()];
+                    let params = borsh::__maybestd::vec![<K>::declaration(), <V>::declaration()];
                     format!(r#"{}<{}>"#, "A", params.join(", "))
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::NamedFields(borsh::maybestd::vec![
+                    let fields = borsh::schema::Fields::NamedFields(borsh::__maybestd::vec![
                         ("x".to_string(), <HashMap<K, V> as borsh::BorshSchema >::declaration()),
                         ("y".to_string(), <String as borsh::BorshSchema>::declaration())
                     ]);
@@ -410,7 +410,7 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
@@ -445,12 +445,12 @@ mod tests {
                     "A".to_string()
                 }
                 fn add_definitions_recursively(
-                    definitions: &mut borsh::maybestd::collections::HashMap<
+                    definitions: &mut borsh::__maybestd::collections::HashMap<
                         borsh::schema::Declaration,
                         borsh::schema::Definition
                     >
                 ) {
-                    let fields = borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![<String as borsh::BorshSchema>::declaration()]);
+                    let fields = borsh::schema::Fields::UnnamedFields(borsh::__maybestd::vec![<String as borsh::BorshSchema>::declaration()]);
                     let definition = borsh::schema::Definition::Struct { fields };
                     Self::add_definition(Self::declaration(), definition, definitions);
                     <String as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -9,7 +9,7 @@ use core::{
 #[cfg(any(test, feature = "bytes"))]
 use bytes::{BufMut, BytesMut};
 
-use crate::maybestd::{
+use crate::__maybestd::{
     borrow::{Borrow, Cow, ToOwned},
     boxed::Box,
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
@@ -21,7 +21,7 @@ use crate::maybestd::{
 };
 
 #[cfg(feature = "rc")]
-use crate::maybestd::{rc::Rc, sync::Arc};
+use crate::__maybestd::{rc::Rc, sync::Arc};
 
 mod hint;
 
@@ -99,14 +99,14 @@ pub trait EnumExt: BorshDeserialize {
     /// struct OneOrZero(MyEnum);
     ///
     /// impl borsh::de::BorshDeserialize for OneOrZero {
-    ///     fn deserialize_reader<R: borsh::maybestd::io::Read>(
+    ///     fn deserialize_reader<R: borsh::__maybestd::io::Read>(
     ///         reader: &mut R,
-    ///     ) -> borsh::maybestd::io::Result<Self> {
+    ///     ) -> borsh::__maybestd::io::Result<Self> {
     ///         use borsh::de::EnumExt;
     ///         let tag = u8::deserialize_reader(reader)?;
     ///         if tag == 2 {
-    ///             Err(borsh::maybestd::io::Error::new(
-    ///                 borsh::maybestd::io::ErrorKind::InvalidInput,
+    ///             Err(borsh::__maybestd::io::Error::new(
+    ///                 borsh::__maybestd::io::ErrorKind::InvalidInput,
     ///                 "MyEnum::Many not allowed here",
     ///             ))
     ///         } else {

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -22,8 +22,9 @@ pub use ser::BorshSerialize;
 /// A facade around all the types we need from the `std`, `core`, and `alloc`
 /// crates. This avoids elaborate import wrangling having to happen in every
 /// module.
+#[doc(hidden)]
 #[cfg(feature = "std")]
-pub mod maybestd {
+pub mod __maybestd {
     pub use std::{borrow, boxed, collections, format, io, string, vec};
 
     #[cfg(feature = "rc")]
@@ -33,8 +34,9 @@ pub mod maybestd {
 #[cfg(not(feature = "std"))]
 mod nostd_io;
 
+#[doc(hidden)]
 #[cfg(not(feature = "std"))]
-pub mod maybestd {
+pub mod __maybestd {
     pub use alloc::{borrow, boxed, format, string, vec};
 
     #[cfg(feature = "rc")]

--- a/borsh/src/nostd_io.rs
+++ b/borsh/src/nostd_io.rs
@@ -1,6 +1,6 @@
 //! Taken from https://github.com/bbqsrc/bare-io (with adjustments)
 
-use crate::maybestd::string::String;
+use crate::__maybestd::string::String;
 use core::{convert::From, fmt, result};
 
 /// A specialized [`Result`] type for I/O operations.

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -12,8 +12,8 @@
 
 #![allow(dead_code)] // Unclear why rust check complains on fields of `Definition` variants.
 use crate as borsh; // For `#[derive(BorshSerialize, BorshDeserialize)]`.
-use crate::maybestd::collections::{BTreeMap, BTreeSet};
-use crate::maybestd::{
+use crate::__maybestd::collections::{BTreeMap, BTreeSet};
+use crate::__maybestd::{
     boxed::Box,
     collections::{hash_map::Entry, HashMap, HashSet},
     format,
@@ -375,7 +375,7 @@ impl_tuple!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::maybestd::collections::HashMap;
+    use crate::__maybestd::collections::HashMap;
 
     macro_rules! map(
     () => { HashMap::new() };

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -1,8 +1,8 @@
-use crate::from_slice;
-use crate::maybestd::{
+use crate::__maybestd::{
     io::{Error, ErrorKind, Result},
     vec::Vec,
 };
+use crate::from_slice;
 use crate::schema::BorshSchemaContainer;
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
 

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,8 +1,8 @@
-use crate::maybestd::{
+use crate::BorshSerialize;
+use crate::__maybestd::{
     io::{Result, Write},
     vec::Vec,
 };
-use crate::BorshSerialize;
 
 /// Serialize an object into a vector of bytes.
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -3,7 +3,7 @@ use core::hash::BuildHasher;
 use core::marker::PhantomData;
 use core::mem::size_of;
 
-use crate::maybestd::{
+use crate::__maybestd::{
     borrow::{Cow, ToOwned},
     boxed::Box,
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
@@ -13,7 +13,7 @@ use crate::maybestd::{
 };
 
 #[cfg(feature = "rc")]
-use crate::maybestd::{rc::Rc, sync::Arc};
+use crate::__maybestd::{rc::Rc, sync::Arc};
 
 pub(crate) mod helpers;
 

--- a/borsh/tests/test_binary_heaps.rs
+++ b/borsh/tests/test_binary_heaps.rs
@@ -1,4 +1,4 @@
-use borsh::maybestd::collections::BinaryHeap;
+use borsh::__maybestd::collections::BinaryHeap;
 use borsh::{from_slice, BorshSerialize};
 
 macro_rules! test_binary_heap {

--- a/borsh/tests/test_custom_reader.rs
+++ b/borsh/tests/test_custom_reader.rs
@@ -75,8 +75,8 @@ struct CustomReader {
     read_index: usize,
 }
 
-impl borsh::maybestd::io::Read for CustomReader {
-    fn read(&mut self, buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
+impl borsh::__maybestd::io::Read for CustomReader {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::__maybestd::io::Result<usize> {
         let len = buf.len().min(self.data.len() - self.read_index);
         buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
         self.read_index += len;
@@ -107,8 +107,8 @@ struct CustomReaderThatDoesntFillSlices {
     read_index: usize,
 }
 
-impl borsh::maybestd::io::Read for CustomReaderThatDoesntFillSlices {
-    fn read(&mut self, buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
+impl borsh::__maybestd::io::Read for CustomReaderThatDoesntFillSlices {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::__maybestd::io::Result<usize> {
         let len = buf.len().min(self.data.len() - self.read_index);
         let len = if len <= 1 { len } else { len / 2 };
         buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
@@ -125,16 +125,16 @@ fn test_custom_reader_that_fails_preserves_error_information() {
     assert_eq!(err.to_string(), "I don't like to run");
     assert_eq!(
         err.kind(),
-        borsh::maybestd::io::ErrorKind::ConnectionAborted
+        borsh::__maybestd::io::ErrorKind::ConnectionAborted
     );
 }
 
 struct CustomReaderThatFails;
 
-impl borsh::maybestd::io::Read for CustomReaderThatFails {
-    fn read(&mut self, _buf: &mut [u8]) -> borsh::maybestd::io::Result<usize> {
-        Err(borsh::maybestd::io::Error::new(
-            borsh::maybestd::io::ErrorKind::ConnectionAborted,
+impl borsh::__maybestd::io::Read for CustomReaderThatFails {
+    fn read(&mut self, _buf: &mut [u8]) -> borsh::__maybestd::io::Result<usize> {
+        Err(borsh::__maybestd::io::Error::new(
+            borsh::__maybestd::io::ErrorKind::ConnectionAborted,
             "I don't like to run",
         ))
     }

--- a/borsh/tests/test_hash_map.rs
+++ b/borsh/tests/test_hash_map.rs
@@ -3,7 +3,7 @@ use core::hash::BuildHasher;
 #[cfg(feature = "std")]
 use std::collections::hash_map::{DefaultHasher, RandomState};
 
-use borsh::maybestd::collections::HashMap;
+use borsh::__maybestd::collections::HashMap;
 use borsh::{from_slice, BorshSerialize};
 
 #[test]

--- a/borsh/tests/test_rc.rs
+++ b/borsh/tests/test_rc.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "rc")]
 
-use borsh::maybestd::rc::Rc;
-use borsh::maybestd::sync::Arc;
+use borsh::__maybestd::rc::Rc;
+use borsh::__maybestd::sync::Arc;
 use borsh::{from_slice, BorshSerialize};
 
 #[test]

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)] // Local structures do not have their fields used.
-use borsh::maybestd::collections::HashMap;
+use borsh::__maybestd::collections::HashMap;
 use borsh::schema::*;
 use borsh::schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
 

--- a/borsh/tests/test_schema_nested.rs
+++ b/borsh/tests/test_schema_nested.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)] // Local structures do not have their fields used.
-use borsh::maybestd::collections::HashMap;
+use borsh::__maybestd::collections::HashMap;
 use borsh::schema::*;
 
 macro_rules! map(

--- a/borsh/tests/test_schema_structs.rs
+++ b/borsh/tests/test_schema_structs.rs
@@ -1,4 +1,4 @@
-use borsh::maybestd::collections::HashMap;
+use borsh::__maybestd::collections::HashMap;
 use borsh::schema::*;
 
 macro_rules! map(

--- a/borsh/tests/test_schema_tuple.rs
+++ b/borsh/tests/test_schema_tuple.rs
@@ -1,4 +1,4 @@
-use borsh::maybestd::collections::HashMap;
+use borsh::__maybestd::collections::HashMap;
 use borsh::schema::*;
 
 macro_rules! map(

--- a/borsh/tests/test_simple_structs.rs
+++ b/borsh/tests/test_simple_structs.rs
@@ -1,4 +1,4 @@
-use borsh::maybestd::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+use borsh::__maybestd::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytes::{Bytes, BytesMut};
 


### PR DESCRIPTION
despite it being technically available by new name of `__maybestd`. 
This PR is a small fraction of #51 