### PR TITLE
chore: simpler bounds on Rc/Arc impls

### DIFF
--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -835,26 +835,22 @@ impl_tuple!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18);
 impl_tuple!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19);
 
 #[cfg(feature = "rc")]
-impl<T, U> BorshDeserialize for Rc<T>
+impl<T: ?Sized> BorshDeserialize for Rc<T>
 where
-    U: Into<Rc<T>> + Borrow<T>,
-    T: ToOwned<Owned = U> + ?Sized,
-    T::Owned: BorshDeserialize,
+    Box<T>: BorshDeserialize,
 {
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
-        Ok(T::Owned::deserialize_reader(reader)?.into())
+        Ok(Box::<T>::deserialize_reader(reader)?.into())
     }
 }
 
 #[cfg(feature = "rc")]
-impl<T, U> BorshDeserialize for Arc<T>
+impl<T: ?Sized> BorshDeserialize for Arc<T>
 where
-    U: Into<Arc<T>> + Borrow<T>,
-    T: ToOwned<Owned = U> + ?Sized,
-    T::Owned: BorshDeserialize,
+    Box<T>: BorshDeserialize,
 {
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
-        Ok(T::Owned::deserialize_reader(reader)?.into())
+        Ok(Box::<T>::deserialize_reader(reader)?.into())
     }
 }
 

--- a/borsh/tests/test_rc.rs
+++ b/borsh/tests/test_rc.rs
@@ -20,9 +20,27 @@ fn test_rc_roundtrip() {
 }
 
 #[test]
+fn test_slice_rc() {
+    let original: &[i32] = &[1, 2, 3, 4, 6, 9, 10];
+    let shared: rc::Rc<[i32]> = rc::Rc::from(original);
+    let serialized = shared.try_to_vec().unwrap();
+    let deserialized = from_slice::<rc::Rc<[i32]>>(&serialized).unwrap();
+    assert_eq!(original, &*deserialized);
+}
+
+#[test]
 fn test_arc_roundtrip() {
     let value = sync::Arc::new(8u8);
     let serialized = value.try_to_vec().unwrap();
     let deserialized = from_slice::<sync::Arc<u8>>(&serialized).unwrap();
     assert_eq!(value, deserialized);
+}
+
+#[test]
+fn test_slice_arc() {
+    let original: &[i32] = &[1, 2, 3, 4, 6, 9, 10];
+    let shared: sync::Arc<[i32]> = sync::Arc::from(original);
+    let serialized = shared.try_to_vec().unwrap();
+    let deserialized = from_slice::<sync::Arc<[i32]>>(&serialized).unwrap();
+    assert_eq!(original, &*deserialized);
 }


### PR DESCRIPTION
It's a small fragment of #51 
Adjusted from [serde](https://github.com/serde-rs/serde/blob/master/serde/src/de/impls.rs#L1908-L1933)