### PR TITLE
fix: filter out foreign attributes in `BorshSchema` derive for enum

### DIFF
--- a/borsh-schema-derive-internal/src/helpers.rs
+++ b/borsh-schema-derive-internal/src/helpers.rs
@@ -8,6 +8,19 @@ pub fn contains_skip(attrs: &[Attribute]) -> bool {
         .any(|attr| attr.path().to_token_stream().to_string().as_str() == "borsh_skip")
 }
 
+pub fn filter_skip(attrs: &[Attribute]) -> Vec<Attribute> {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            if attr.path().to_token_stream().to_string().as_str() == "borsh_skip" {
+                Some(attr.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 pub fn declaration(
     ident_str: &str,
     generics: &Generics,

--- a/borsh-schema-derive-internal/src/helpers.rs
+++ b/borsh-schema-derive-internal/src/helpers.rs
@@ -8,17 +8,8 @@ pub fn contains_skip(attrs: &[Attribute]) -> bool {
         .any(|attr| attr.path().to_token_stream().to_string().as_str() == "borsh_skip")
 }
 
-pub fn filter_skip(attrs: &[Attribute]) -> Vec<Attribute> {
-    attrs
-        .iter()
-        .filter_map(|attr| {
-            if attr.path().to_token_stream().to_string().as_str() == "borsh_skip" {
-                Some(attr.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
+pub fn filter_skip(attrs: impl Iterator<Item = Attribute>) -> impl Iterator<Item = Attribute> {
+    attrs.filter(|attr| attr.path().to_token_stream().to_string().as_str() == "borsh_skip")
 }
 
 pub fn declaration(

--- a/borsh-schema-derive-internal/src/snapshots/borsh_schema_derive_internal__enum_schema__tests__filter_foreign_attrs.snap
+++ b/borsh-schema-derive-internal/src/snapshots/borsh_schema_derive_internal__enum_schema__tests__filter_foreign_attrs.snap
@@ -1,0 +1,40 @@
+---
+source: borsh-schema-derive-internal/src/enum_schema.rs
+expression: pretty_print_syn_str(&actual).unwrap()
+---
+impl borsh::BorshSchema for A {
+    fn declaration() -> borsh::schema::Declaration {
+        "A".to_string()
+    }
+    fn add_definitions_recursively(
+        definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
+            borsh::schema::Declaration,
+            borsh::schema::Definition,
+        >,
+    ) {
+        #[allow(dead_code)]
+        #[derive(borsh::BorshSchema)]
+        struct AB {
+            c: i32,
+            #[borsh_skip]
+            d: u32,
+            l: u64,
+        }
+        #[allow(dead_code)]
+        #[derive(borsh::BorshSchema)]
+        struct ANegative {
+            beta: String,
+        }
+        <AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        let variants = borsh::__private::maybestd::vec![
+            ("B".to_string(), < AB > ::declaration()), ("Negative".to_string(), <
+            ANegative > ::declaration())
+        ];
+        let definition = borsh::schema::Definition::Enum {
+            variants,
+        };
+        Self::add_definition(Self::declaration(), definition, definitions);
+    }
+}
+


### PR DESCRIPTION
Fixes #110 