### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.2...borsh-v1.0.0-alpha.3) - 2023-08-16
+
+### Other
+- [**breaking**] renamed #[borsh_skip] to #[borsh(skip)] ([#192](https://github.com/near/borsh-rs/pull/192))
+- split up schema derive functions ([#191](https://github.com/near/borsh-rs/pull/191))
+
 ## [1.0.0-alpha.2](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.1...borsh-v1.0.0-alpha.2) - 2023-08-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["std", "derive", "schema"]
 cfg_aliases = "0.1.0"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.2", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.3", optional = true }
 hashbrown = { version = ">=0.11,<0.14", optional = true }
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)
* `borsh-derive`: 1.0.0-alpha.2 -> 1.0.0-alpha.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.0.0-alpha.3](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.2...borsh-v1.0.0-alpha.3) - 2023-08-16

### Other
- [**breaking**] renamed #[borsh_skip] to #[borsh(skip)] ([#192](https://github.com/near/borsh-rs/pull/192))
- split up schema derive functions ([#191](https://github.com/near/borsh-rs/pull/191))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).