### PR TITLE
feat!: forbid multiple `borsh` attr occurencies

### DIFF
--- a/borsh-derive/src/internals/attributes/field/snapshots/reject_multiple_borsh_attrs.snap
+++ b/borsh-derive/src/internals/attributes/field/snapshots/reject_multiple_borsh_attrs.snap
@@ -1,0 +1,7 @@
+---
+source: borsh-derive/src/internals/attributes/field/mod.rs
+expression: err
+---
+Error(
+    "multiple `borsh` attributes not allowed",
+)

--- a/borsh-derive/src/internals/attributes/item/snapshots/reject_multiple_borsh_attrs.snap
+++ b/borsh-derive/src/internals/attributes/item/snapshots/reject_multiple_borsh_attrs.snap
@@ -1,0 +1,5 @@
+---
+source: borsh-derive/src/internals/attributes/item/mod.rs
+expression: actual.unwrap_err().to_token_stream().to_string()
+---
+:: core :: compile_error ! { "multiple `borsh` attributes not allowed" }

--- a/borsh-derive/src/internals/attributes/mod.rs
+++ b/borsh-derive/src/internals/attributes/mod.rs
@@ -1,4 +1,4 @@
-use syn::Path;
+use syn::{Attribute, Path};
 
 pub mod field;
 pub mod item;
@@ -60,4 +60,16 @@ impl<'a> PartialEq<Symbol> for &'a Path {
     fn eq(&self, word: &Symbol) -> bool {
         self.is_ident(word.0)
     }
+}
+
+fn get_one_attribute(attrs: &[Attribute]) -> syn::Result<Option<&Attribute>> {
+    let count = attrs.iter().filter(|attr| attr.path() == BORSH).count();
+    let borsh = attrs.iter().find(|attr| attr.path() == BORSH);
+    if count > 1 {
+        return Err(syn::Error::new_spanned(
+            borsh.unwrap(),
+            format!("multiple `{}` attributes not allowed", BORSH.0),
+        ));
+    }
+    Ok(borsh)
 }


### PR DESCRIPTION
Context:

We either needed to implement attributes merging or forbid multiple attribute occurences. We decided that the latter is easier to implement, and it won't be a breaking change to relax this requirement in the future, if needed.