### PR TITLE
chore: revert`#[non_exhaustive]` on `borsh::schema::Definition`

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -33,7 +33,6 @@ pub type VariantName = String;
 pub type FieldName = String;
 /// The type that we use to represent the definition of the Borsh type.
 
-#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Debug, BorshSerialize, BorshDeserialize, BorshSchemaMacro)]
 pub enum Definition {
     /// A fixed-size array with the length known at the compile time and the same-type elements.


### PR DESCRIPTION
it's part of #194 resolution.

allows not to have a `serde` derivation expanded and patched in [near-abi-rs#23](https://github.com/near/near-abi-rs/pull/23)