### PR TITLE
chore!: `PartialOrd` -> `Ord` bound for hashcollections

### DIFF
--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -83,13 +83,13 @@ Attribute adds possibility to override bounds for `BorshSerialize` in order to e
 2. fixing complex cases, when derive hasn't figured out the right bounds on type parameters automatically.
 
 ```ignore
-/// additional bound `T: PartialOrd` (required by `HashMap`) is injected into
+/// additional bound `T: Ord` (required by `HashMap`) is injected into
 /// derived trait implementation via attribute to avoid adding the bounds on the struct itself
 #[derive(BorshSerialize)]
 struct A<T, U> {
     a: String,
     #[borsh(bound(serialize =
-        "T: borsh::ser::BorshSerialize + PartialOrd,
+        "T: borsh::ser::BorshSerialize + Ord,
          U: borsh::ser::BorshSerialize"))]
     b: HashMap<T, U>,
 }
@@ -360,14 +360,14 @@ Attribute adds possibility to override bounds for `BorshDeserialize` in order to
 2. fixing complex cases, when derive hasn't figured out the right bounds on type parameters automatically.
 
 ```ignore
-/// additional bounds `T: PartialOrd + Hash + Eq` (required by `HashMap`) are injected into
+/// additional bounds `T: Ord + Hash + Eq` (required by `HashMap`) are injected into
 /// derived trait implementation via attribute to avoid adding the bounds on the struct itself
 #[derive(BorshDeserialize)]
 struct A<T, U> {
     a: String,
     #[borsh(bound(
         deserialize =
-        "T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
+        "T: Ord + Hash + Eq + borsh::de::BorshDeserialize,
          U: borsh::de::BorshDeserialize"
     ))]
     b: HashMap<T, U>,

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -490,12 +490,10 @@ pub mod hashes {
     #[cfg(feature = "de_strict_order")]
     use crate::__private::maybestd::io::{Error, ErrorKind};
     use crate::error::check_zst;
-    #[cfg(feature = "de_strict_order")]
-    use core::cmp::Ordering;
 
     impl<T, H> BorshDeserialize for HashSet<T, H>
     where
-        T: BorshDeserialize + Eq + Hash + PartialOrd,
+        T: BorshDeserialize + Eq + Hash + Ord,
         H: BuildHasher + Default,
     {
         #[inline]
@@ -513,7 +511,7 @@ pub mod hashes {
                 let [a, b] = pair else {
                     unreachable!("`windows` always return a slice of length 2 or nothing");
                 };
-                let cmp_result = a.partial_cmp(b).map_or(false, Ordering::is_lt);
+                let cmp_result = a.cmp(b).is_lt();
                 if !cmp_result {
                     return Err(Error::new(
                         ErrorKind::InvalidData,
@@ -528,7 +526,7 @@ pub mod hashes {
 
     impl<K, V, H> BorshDeserialize for HashMap<K, V, H>
     where
-        K: BorshDeserialize + Eq + Hash + PartialOrd,
+        K: BorshDeserialize + Eq + Hash + Ord,
         V: BorshDeserialize,
         H: BuildHasher + Default,
     {
@@ -548,7 +546,7 @@ pub mod hashes {
                 let [(a_k, _a_v), (b_k, _b_v)] = pair else {
                     unreachable!("`windows` always return a slice of length 2 or nothing");
                 };
-                let cmp_result = a_k.partial_cmp(b_k).map_or(false, Ordering::is_lt);
+                let cmp_result = a_k.cmp(b_k).is_lt();
                 if !cmp_result {
                     return Err(Error::new(
                         ErrorKind::InvalidData,

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -43,6 +43,7 @@
   are encountered in ascending order with respect to [PartialOrd](core::cmp::PartialOrd) for hash collections,
   and [Ord](core::cmp::Ord) for btree ones. Deserialization emits error otherwise.
 
+  If this feature is not enabled, it is possible that two different byte slices could deserialize into the same `HashMap`/`HashSet` object.
 
 ### Config aliases
 

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -364,7 +364,7 @@ pub mod hashes {
 
     impl<K, V, H> BorshSerialize for HashMap<K, V, H>
     where
-        K: BorshSerialize + PartialOrd,
+        K: BorshSerialize + Ord,
         V: BorshSerialize,
         H: BuildHasher,
     {
@@ -373,7 +373,7 @@ pub mod hashes {
             check_zst::<K>()?;
 
             let mut vec = self.iter().collect::<Vec<_>>();
-            vec.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap());
+            vec.sort_by(|(a, _), (b, _)| a.cmp(b));
             u32::try_from(vec.len())
                 .map_err(|_| ErrorKind::InvalidData)?
                 .serialize(writer)?;
@@ -387,7 +387,7 @@ pub mod hashes {
 
     impl<T, H> BorshSerialize for HashSet<T, H>
     where
-        T: BorshSerialize + PartialOrd,
+        T: BorshSerialize + Ord,
         H: BuildHasher,
     {
         #[inline]
@@ -395,7 +395,7 @@ pub mod hashes {
             check_zst::<T>()?;
 
             let mut vec = self.iter().collect::<Vec<_>>();
-            vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            vec.sort();
             u32::try_from(vec.len())
                 .map_err(|_| ErrorKind::InvalidData)?
                 .serialize(writer)?;

--- a/borsh/tests/test_generic_struct.rs
+++ b/borsh/tests/test_generic_struct.rs
@@ -54,7 +54,7 @@ struct NamedA<T> {
 /// `T: Hash + Eq` bound is required for `BorshDeserialize` derive to be successful
 #[cfg(hash_collections)]
 #[derive(BorshSerialize, BorshDeserialize)]
-struct C<T: PartialOrd + Hash + Eq, U> {
+struct C<T: Ord + Hash + Eq, U> {
     a: String,
     b: HashMap<T, U>,
 }
@@ -65,7 +65,7 @@ struct C<T: PartialOrd + Hash + Eq, U> {
 #[derive(BorshSerialize)]
 struct C1<T, U> {
     a: String,
-    #[borsh(bound(serialize = "T: borsh::ser::BorshSerialize + PartialOrd,
+    #[borsh(bound(serialize = "T: borsh::ser::BorshSerialize + Ord,
          U: borsh::ser::BorshSerialize"))]
     b: HashMap<T, U>,
 }
@@ -77,10 +77,8 @@ struct C1<T, U> {
 #[derive(BorshDeserialize)]
 struct C2<T, U> {
     a: String,
-    #[borsh(bound(
-        deserialize = "T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
-         U: borsh::de::BorshDeserialize"
-    ))]
+    #[borsh(bound(deserialize = "T: Ord + Hash + Eq + borsh::de::BorshDeserialize,
+         U: borsh::de::BorshDeserialize"))]
     b: HashMap<T, U>,
 }
 
@@ -101,7 +99,7 @@ struct G1<K, V, U>(#[borsh(skip)] HashMap<K, V>, U);
 
 #[cfg(hash_collections)]
 #[derive(BorshDeserialize)]
-struct G2<K: PartialOrd + Hash + Eq, V, U>(HashMap<K, V>, #[borsh(skip)] U);
+struct G2<K: Ord + Hash + Eq, V, U>(HashMap<K, V>, #[borsh(skip)] U);
 
 /// implicit derived `core::default::Default` bounds on `K` and `V` are dropped by empty bound
 /// specified, as `HashMap` hash its own `Default` implementation
@@ -139,7 +137,7 @@ enum I1<K, V, U> {
 
 #[cfg(hash_collections)]
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-enum I2<K: PartialOrd + Eq + Hash, V, U> {
+enum I2<K: Ord + Eq + Hash, V, U> {
     B { x: HashMap<K, V>, y: String },
     C(K, #[borsh(skip)] U),
 }

--- a/borsh/tests/test_recursive_structs.rs
+++ b/borsh/tests/test_recursive_structs.rs
@@ -17,7 +17,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[cfg(hash_collections)]
 #[derive(BorshSerialize, BorshDeserialize)]
-struct CRec<U: PartialOrd + Hash + Eq> {
+struct CRec<U: Ord + Hash + Eq> {
     a: String,
     b: HashMap<U, CRec<U>>,
 }


### PR DESCRIPTION
This pr is part of #51 resolution.

It addresses the following comments of [review](https://github.com/near/borsh-rs/issues/51#issuecomment-1684317118):

![tmp](https://github.com/near/borsh-rs/assets/26653921/5b7c4837-486e-4ed3-aebb-608dca26499c)
![tmp](https://github.com/near/borsh-rs/assets/26653921/44843861-1127-4df6-8452-b8ecbd701180)

Second comment is addressed by second [commit: feat!: raise bound on keys in hashcollections PartialOrd -> Ord](https://github.com/near/borsh-rs/pull/203/commits/d5ac0a5f03682b725c50a66003a642acb0650a2b). 
Code with `f32` and `f64` won't be affected by this breaking change, as `f32` and `f64` aren't `Eq`, so it's not possible to construct `HashSet` or `HashMap` with these types as keys in the first place (`insert` in both collections require `Eq` bound).