### PR TITLE
chore!: make `BorshSchema::{add_definition,schema_container}` free-standing funcs

### DIFF
--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -55,7 +55,7 @@ pub fn process(input: &ItemEnum, cratename: Ident) -> syn::Result<TokenStream2> 
             #add_recursive_defs
             let variants = #cratename::__private::maybestd::vec![#(#variants_defs),*];
             let definition = #cratename::schema::Definition::Enum{variants};
-            Self::add_definition(Self::declaration(), definition, definitions);
+            #cratename::schema::add_definition(Self::declaration(), definition, definitions);
         }
     };
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -39,7 +39,7 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -46,7 +46,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -49,7 +49,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -47,7 +47,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -34,7 +34,7 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -60,7 +60,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -61,7 +61,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -41,7 +41,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -27,7 +27,7 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -22,7 +22,7 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -44,7 +44,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -45,7 +45,7 @@ where
         let definition = borsh::schema::Definition::Enum {
             variants,
         };
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }
 }
 

--- a/borsh-derive/src/internals/schema/structs/mod.rs
+++ b/borsh-derive/src/internals/schema/structs/mod.rs
@@ -64,7 +64,7 @@ pub fn process(input: &ItemStruct, cratename: Ident) -> syn::Result<TokenStream2
             let definition = #cratename::schema::Definition::Struct { fields };
 
             let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-            Self::add_definition(Self::declaration(), definition, definitions);
+            #cratename::schema::add_definition(Self::declaration(), definition, definitions);
             if no_recursion_flag {
                 #add_definitions_recursively
             }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
@@ -31,7 +31,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <T::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
@@ -31,7 +31,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <<T as TraitName>::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
@@ -33,7 +33,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <(
                 <T as TraitName>::Associated,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -25,7 +25,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -23,7 +23,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -28,7 +28,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
@@ -29,7 +29,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
@@ -22,7 +22,7 @@ impl<C> borsh::BorshSchema for ASalad<C> {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <Tomatoes as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <Oil as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
@@ -23,7 +23,7 @@ impl borsh::BorshSchema for CRecC {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <HashMap<

--- a/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
@@ -27,7 +27,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <PrimaryMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
@@ -30,7 +30,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
@@ -22,7 +22,7 @@ impl borsh::BorshSchema for A {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
@@ -31,7 +31,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
@@ -22,7 +22,7 @@ impl borsh::BorshSchema for A {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
@@ -29,7 +29,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <V as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
@@ -21,7 +21,7 @@ impl borsh::BorshSchema for A {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
@@ -17,7 +17,7 @@ impl borsh::BorshSchema for A {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {}
     }
 }

--- a/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
@@ -17,7 +17,7 @@ impl borsh::BorshSchema for A {
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {}
     }
 }

--- a/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
@@ -29,7 +29,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             third_party_impl::add_definitions_recursively::<K, V>(definitions);
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
@@ -23,7 +23,7 @@ where
             fields,
         };
         let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        Self::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(Self::declaration(), definition, definitions);
         if no_recursion_flag {
             <T as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh/src/generate_schema_schema.rs
+++ b/borsh/src/generate_schema_schema.rs
@@ -1,13 +1,13 @@
 //! Generate `BorshSchemaCointainer` for `BorshSchemaContainer` and save it into a file.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-use borsh::schema::BorshSchema;
-use borsh::BorshSerialize;
+use borsh::{schema_container_of, BorshSerialize};
 use std::fs::File;
 use std::io::Write;
 
 fn main() {
-    let container = borsh::schema::BorshSchemaContainer::schema_container();
+    let container = schema_container_of::<borsh::schema::BorshSchemaContainer>();
+
     println!("{:#?}", container);
     let data = container
         .try_to_vec()

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -21,7 +21,7 @@
   [BorshDeserialize](crate::de::BorshDeserialize) traits.
 * **schema** -
   Gates [BorshSchema](crate::schema::BorshSchema) trait and its derive macro.
-  Gates [schema](crate::schema) and [schema_helpers](crate::schema_helpers) modules.
+  Gates [schema](crate::schema) module.
   This feature requires **derive** to be enabled too.
 * **rc** -
   Gates implementation of [BorshSerialize](crate::ser::BorshSerialize) and [BorshDeserialize](crate::de::BorshDeserialize)
@@ -77,7 +77,7 @@ pub mod de;
 pub mod schema;
 /// Module is available if borsh is built with `features = ["derive", "schema"]`.
 #[cfg(derive_schema)]
-pub mod schema_helpers;
+pub(crate) mod schema_helpers;
 pub mod ser;
 
 pub use de::BorshDeserialize;
@@ -85,7 +85,7 @@ pub use de::{from_reader, from_slice};
 #[cfg(derive_schema)]
 pub use schema::BorshSchema;
 #[cfg(derive_schema)]
-pub use schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
+pub use schema_helpers::{schema_container_of, try_from_slice_with_schema, try_to_vec_with_schema};
 pub use ser::helpers::{to_vec, to_writer};
 pub use ser::BorshSerialize;
 pub mod error;

--- a/borsh/tests/smoke.rs
+++ b/borsh/tests/smoke.rs
@@ -9,13 +9,14 @@ use alloc::vec;
 
 use borsh::{self, from_slice};
 #[cfg(feature = "schema")]
-use borsh::{try_from_slice_with_schema, BorshSchema};
+use borsh::{schema_container_of, try_from_slice_with_schema};
 
 #[cfg(feature = "schema")]
 #[test]
 fn test_to_vec() {
     let value = 42u8;
-    let seriazeble = (<u8 as BorshSchema>::schema_container(), value);
+
+    let seriazeble = (schema_container_of::<u8>(), value);
     let serialized = borsh::to_vec(&seriazeble).unwrap();
     #[cfg(feature = "std")]
     println!("serialized: {:?}", serialized);

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -17,7 +17,7 @@ use alloc::{
 };
 
 use borsh::schema::*;
-use borsh::schema_helpers::{try_from_slice_with_schema, try_to_vec_with_schema};
+use borsh::{try_from_slice_with_schema, try_to_vec_with_schema};
 
 macro_rules! map(
     () => { BTreeMap::new() };

--- a/borsh/tests/test_schema_primitives.rs
+++ b/borsh/tests/test_schema_primitives.rs
@@ -7,11 +7,12 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
-use borsh::schema::*;
+use borsh::{schema::*, schema_container_of};
 
 #[test]
 fn isize_schema() {
-    let schema = isize::schema_container();
+    let schema = schema_container_of::<isize>();
+
     assert_eq!(
         schema,
         BorshSchemaContainer::new("i64".to_string(), Default::default())
@@ -20,7 +21,8 @@ fn isize_schema() {
 
 #[test]
 fn usize_schema() {
-    let schema = usize::schema_container();
+    let schema = schema_container_of::<usize>();
+
     assert_eq!(
         schema,
         BorshSchemaContainer::new("u64".to_string(), Default::default())

--- a/borsh/tests/test_schema_with.rs
+++ b/borsh/tests/test_schema_with.rs
@@ -64,7 +64,7 @@ mod third_party_impl {
         ]);
         let definition = borsh::schema::Definition::Struct { fields };
         let no_recursion_flag = definitions.get(&declaration::<K, V>()).is_none();
-        <() as BorshSchema>::add_definition(declaration::<K, V>(), definition, definitions);
+        borsh::schema::add_definition(declaration::<K, V>(), definition, definitions);
         if no_recursion_flag {
             <BTreeMap<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }


### PR DESCRIPTION
Part of #51 resolution

This pr addresses the following comments of [review](https://github.com/near/borsh-rs/issues/51#issuecomment-1684317118):

![tmp](https://github.com/near/borsh-rs/assets/26653921/9d88bfa1-ece6-4157-8bef-5b1c802c07b2)
![tmp](https://github.com/near/borsh-rs/assets/26653921/34ea2da2-7833-455d-8d7a-d5dbe8c4c7c5)
![tmp](https://github.com/near/borsh-rs/assets/26653921/a775881a-7ae5-4a3d-8838-5b841d17a909)
![tmp](https://github.com/near/borsh-rs/assets/26653921/53421403-8988-4039-899e-c08831162c57)
