### PR TITLE
chore!: deprecate `try_to_vec` method from `BorshSerialize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ strict [specification](https://github.com/near/borsh#specification).
 ## Example
 
 ```rust
-use borsh::{BorshSerialize, BorshDeserialize, from_slice};
+use borsh::{BorshSerialize, BorshDeserialize, from_slice, to_vec};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 struct A {
@@ -33,7 +33,7 @@ fn test_simple_struct() {
         x: 3301,
         y: "liber primus".to_string(),
     };
-    let encoded_a = a.try_to_vec().unwrap();
+    let encoded_a = to_vec(&a).unwrap();
     let decoded_a = from_slice::<A>(&encoded_a).unwrap();
     assert_eq!(a, decoded_a);
 }

--- a/benchmarks/benches/bench.rs
+++ b/benchmarks/benches/bench.rs
@@ -1,5 +1,5 @@
 use benchmarks::{Account, Block, BlockHeader, Generate, SignedTransaction};
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 use rand::SeedableRng;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use speedy::Endianness;
@@ -22,7 +22,7 @@ where
     let mut group = c.benchmark_group(group_name);
 
     let objects: Vec<_> = (0..num_samples).map(|_| T::generate(&mut rng)).collect();
-    let borsh_datas: Vec<Vec<u8>> = objects.iter().map(|t| t.try_to_vec().unwrap()).collect();
+    let borsh_datas: Vec<Vec<u8>> = objects.iter().map(|t| to_vec(t).unwrap()).collect();
     let borsh_sizes: Vec<_> = borsh_datas.iter().map(|d| d.len()).collect();
 
     for i in 0..objects.len() {
@@ -50,7 +50,7 @@ where
             BenchmarkId::new("borsh", benchmark_param_display.clone()),
             obj,
             |b, d| {
-                b.iter(|| d.try_to_vec().unwrap());
+                b.iter(|| to_vec(d).unwrap());
             },
         );
         group.bench_with_input(
@@ -87,7 +87,7 @@ where
         .iter()
         .map(|t| bincode::serialize(t).unwrap())
         .collect();
-    let borsh_datas: Vec<Vec<u8>> = objects.iter().map(|t| t.try_to_vec().unwrap()).collect();
+    let borsh_datas: Vec<Vec<u8>> = objects.iter().map(|t| to_vec(t).unwrap()).collect();
     let speedy_datas: Vec<Vec<u8>> = objects
         .iter()
         .map(|t| t.write_to_vec(Endianness::LittleEndian).unwrap())

--- a/benchmarks/benches/maps_sets_inner_de.rs
+++ b/benchmarks/benches/maps_sets_inner_de.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use benchmarks::{Generate, PublicKey};
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::SeedableRng;
 
@@ -21,7 +21,7 @@ where
 
     let collection: U = (0..num_samples).map(|_| T::generate(&mut rng)).collect();
 
-    let serialized: Vec<u8> = collection.try_to_vec().unwrap();
+    let serialized: Vec<u8> = to_vec(&collection).unwrap();
 
     group.bench_with_input(BenchmarkId::new("borsh_de", ""), &serialized, |b, d| {
         b.iter(|| from_slice::<U>(d).unwrap());

--- a/benchmarks/benches/maps_sets_inner_ser.rs
+++ b/benchmarks/benches/maps_sets_inner_ser.rs
@@ -4,7 +4,7 @@ use std::{
     iter::FromIterator,
 };
 
-use borsh::BorshSerialize;
+use borsh::{to_vec, BorshSerialize};
 
 use benchmarks::Generate;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -23,7 +23,7 @@ where
     let collection: U = (0..num_samples).map(|_| T::generate(&mut rng)).collect();
 
     group.bench_with_input(BenchmarkId::new("borsh_ser", ""), &collection, |b, d| {
-        b.iter(|| d.try_to_vec().unwrap());
+        b.iter(|| to_vec(d).unwrap());
     });
 }
 

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -871,7 +871,7 @@ impl<T: ?Sized> BorshDeserialize for PhantomData<T> {
 /// Deserializes an object from a slice of bytes.
 /// # Example
 /// ```
-/// use borsh::{BorshDeserialize, BorshSerialize, from_slice};
+/// use borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec};
 ///
 /// /// derive is only available if borsh is built with `features = ["derive"]`
 /// # #[cfg(feature = "derive")]
@@ -884,7 +884,7 @@ impl<T: ?Sized> BorshDeserialize for PhantomData<T> {
 /// # #[cfg(feature = "derive")]
 /// let original = MyStruct { a: 10, b: vec![1, 2, 3] };
 /// # #[cfg(feature = "derive")]
-/// let encoded = original.try_to_vec().unwrap();
+/// let encoded = to_vec(&original).unwrap();
 /// # #[cfg(feature = "derive")]
 /// let decoded = from_slice::<MyStruct>(&encoded).unwrap();
 /// # #[cfg(feature = "derive")]
@@ -911,7 +911,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// Deserializes an object from a reader.
 /// # Example
 /// ```
-/// use borsh::{BorshDeserialize, BorshSerialize, from_reader};
+/// use borsh::{BorshDeserialize, BorshSerialize, from_reader, to_vec};
 ///
 /// /// derive is only available if borsh is built with `features = ["derive"]`
 /// # #[cfg(feature = "derive")]
@@ -924,7 +924,7 @@ pub fn from_slice<T: BorshDeserialize>(v: &[u8]) -> Result<T> {
 /// # #[cfg(feature = "derive")]
 /// let original = MyStruct { a: 10, b: vec![1, 2, 3] };
 /// # #[cfg(feature = "derive")]
-/// let encoded = original.try_to_vec().unwrap();
+/// let encoded = to_vec(&original).unwrap();
 /// # #[cfg(feature = "derive")]
 /// let decoded = from_reader::<_, MyStruct>(&mut encoded.as_slice()).unwrap();
 /// # #[cfg(feature = "derive")]

--- a/borsh/src/generate_schema_schema.rs
+++ b/borsh/src/generate_schema_schema.rs
@@ -1,7 +1,7 @@
 //! Generate `BorshSchemaCointainer` for `BorshSchemaContainer` and save it into a file.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-use borsh::{schema_container_of, BorshSerialize};
+use borsh::schema_container_of;
 use std::fs::File;
 use std::io::Write;
 
@@ -9,9 +9,8 @@ fn main() {
     let container = schema_container_of::<borsh::schema::BorshSchemaContainer>();
 
     println!("{:#?}", container);
-    let data = container
-        .try_to_vec()
-        .expect("Failed to serialize BorshSchemaContainer");
+
+    let data = borsh::to_vec(&container).expect("Failed to serialize BorshSchemaContainer");
     let mut file = File::create("schema_schema.dat").expect("Failed to create file");
     file.write_all(&data).expect("Failed to write file");
 }

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -25,7 +25,7 @@ pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -
 /// bytes in Borsh format.
 pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema>(value: &T) -> Result<Vec<u8>> {
     let schema = schema_container_of::<T>();
-    let mut res = schema.try_to_vec()?;
+    let mut res = crate::to_vec(&schema)?;
     value.serialize(&mut res)?;
     Ok(res)
 }

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -4,12 +4,16 @@ use crate::__private::maybestd::{
     vec::Vec,
 };
 
+pub(super) const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
+
 /// Serialize an object into a vector of bytes.
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
     T: BorshSerialize + ?Sized,
 {
-    value.try_to_vec()
+    let mut result = Vec::with_capacity(DEFAULT_SERIALIZER_CAPACITY);
+    value.serialize(&mut result)?;
+    Ok(result)
 }
 
 /// Serializes an object directly into a `Writer`.

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -18,8 +18,6 @@ use crate::__private::maybestd::{rc::Rc, sync::Arc};
 
 pub(crate) mod helpers;
 
-const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
-
 /// A data-structure that can be serialized into binary format by NBOR.
 ///
 /// ```
@@ -57,8 +55,9 @@ pub trait BorshSerialize {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()>;
 
     /// Serialize this instance into a vector of bytes.
+    #[deprecated = "use `borsh::to_vec(&object)` instead"]
     fn try_to_vec(&self) -> Result<Vec<u8>> {
-        let mut result = Vec::with_capacity(DEFAULT_SERIALIZER_CAPACITY);
+        let mut result = Vec::with_capacity(helpers::DEFAULT_SERIALIZER_CAPACITY);
         self.serialize(&mut result)?;
         Ok(result)
     }

--- a/borsh/tests/common_macro.rs
+++ b/borsh/tests/common_macro.rs
@@ -5,7 +5,7 @@ macro_rules! set_insert_deser_assert_macro [
         $($set.insert($key));*
         ;
 
-        let $data = $set.try_to_vec().unwrap();
+        let $data = borsh::to_vec(&$set).unwrap();
         #[cfg(feature = "std")]
         insta::assert_debug_snapshot!($data);
     ]
@@ -17,7 +17,8 @@ macro_rules! map_insert_deser_assert_macro [
     [$map: ident, $data: ident, $($key: expr => $value: expr),*] => [
         $($map.insert($key, $value));*
         ;
-        let $data = $map.try_to_vec().unwrap();
+
+        let $data = borsh::to_vec(&$map).unwrap();
         #[cfg(feature = "std")]
         insta::assert_debug_snapshot!($data);
     ]

--- a/borsh/tests/test_arrays.rs
+++ b/borsh/tests/test_arrays.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::float_cmp)]
 
+use borsh::{from_slice, to_vec};
 #[cfg(feature = "derive")]
-use borsh::BorshDeserialize;
-use borsh::{from_slice, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -12,7 +12,7 @@ use alloc::string::{String, ToString};
 
 macro_rules! test_array {
     ($v: expr, $t: ty, $len: expr) => {
-        let buf = $v.try_to_vec().unwrap();
+        let buf = borsh::to_vec(&$v).unwrap();
         #[cfg(feature = "std")]
         insta::assert_debug_snapshot!(buf);
         let actual_v: [$t; $len] = from_slice(&buf).expect("failed to deserialize");
@@ -63,7 +63,7 @@ struct CustomStruct(u8);
 #[test]
 fn test_custom_struct_array() {
     let arr = [CustomStruct(0), CustomStruct(1), CustomStruct(2)];
-    let serialized = arr.try_to_vec().unwrap();
+    let serialized = to_vec(&arr).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(serialized);
     let deserialized: [CustomStruct; 3] = from_slice(&serialized).unwrap();
@@ -73,7 +73,7 @@ fn test_custom_struct_array() {
 #[test]
 fn test_string_array() {
     let arr = ["0".to_string(), "1".to_string(), "2".to_string()];
-    let serialized = arr.try_to_vec().unwrap();
+    let serialized = to_vec(&arr).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(serialized);
     let deserialized: [String; 3] = from_slice(&serialized).unwrap();

--- a/borsh/tests/test_bson_object_ids.rs
+++ b/borsh/tests/test_bson_object_ids.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::float_cmp)]
 #![cfg(feature = "derive")]
 
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 use bson::oid::ObjectId;
 
 #[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
@@ -15,7 +15,7 @@ fn test_object_id() {
         ObjectId::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
         33,
     );
-    let serialized = obj.try_to_vec().unwrap();
+    let serialized = to_vec(&obj).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(serialized);
     let deserialized: StructWithObjectId = from_slice(&serialized).unwrap();

--- a/borsh/tests/test_custom_reader.rs
+++ b/borsh/tests/test_custom_reader.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg(feature = "derive")]
-use borsh::{from_reader, BorshDeserialize, BorshSerialize};
+use borsh::{from_reader, to_vec, BorshDeserialize, BorshSerialize};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -33,7 +33,7 @@ fn test_custom_reader() {
         item2: "foo".into(),
         item3: 1.2345,
     };
-    let bytes = s.try_to_vec().unwrap();
+    let bytes = to_vec(&s).unwrap();
     let mut reader = CustomReader {
         data: bytes,
         read_index: 0,
@@ -51,7 +51,7 @@ fn test_custom_reader_with_insufficient_data() {
         item2: "foo".into(),
         item3: 1.2345,
     };
-    let mut bytes = s.try_to_vec().unwrap();
+    let mut bytes = to_vec(&s).unwrap();
     bytes.pop().unwrap();
     let mut reader = CustomReader {
         data: bytes,
@@ -72,7 +72,7 @@ fn test_custom_reader_with_too_much_data() {
         item2: "foo".into(),
         item3: 1.2345,
     };
-    let mut bytes = s.try_to_vec().unwrap();
+    let mut bytes = to_vec(&s).unwrap();
     bytes.push(1);
     let mut reader = CustomReader {
         data: bytes,
@@ -107,7 +107,7 @@ fn test_custom_reader_that_doesnt_fill_slices() {
         item2: "foo".into(),
         item3: 1.2345,
     };
-    let bytes = s.try_to_vec().unwrap();
+    let bytes = to_vec(&s).unwrap();
     let mut reader = CustomReaderThatDoesntFillSlices {
         data: bytes,
         read_index: 0,

--- a/borsh/tests/test_enum_discriminants.rs
+++ b/borsh/tests/test_enum_discriminants.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec;
 
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 // sequence, no unit enums
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Copy, Debug)]
 #[borsh(use_discriminant = true)]
@@ -39,7 +39,7 @@ fn test_discriminant_serde_no_unit_type() {
     let expected_discriminants = [0u8, 20, 21, 10, 22, 11];
 
     for (ind, value) in values.iter().enumerate() {
-        let data = value.try_to_vec().unwrap();
+        let data = to_vec(value).unwrap();
         assert_eq!(data[0], expected_discriminants[ind]);
         assert_eq!(from_slice::<XY>(&data).unwrap(), values[ind]);
     }
@@ -58,7 +58,7 @@ fn test_discriminant_serde_no_unit_type_no_use_discriminant() {
     let expected_discriminants = [0u8, 1, 2, 3, 4, 5];
 
     for (ind, value) in values.iter().enumerate() {
-        let data = value.try_to_vec().unwrap();
+        let data = to_vec(value).unwrap();
         assert_eq!(data[0], expected_discriminants[ind]);
         assert_eq!(from_slice::<XYNoDiscriminant>(&data).unwrap(), values[ind]);
     }
@@ -84,17 +84,17 @@ enum MyEnumNoDiscriminant {
 #[test]
 fn test_discriminant_minimal_true() {
     assert_eq!(MyDiscriminantEnum::A as u8, 20);
-    assert_eq!(MyDiscriminantEnum::A.try_to_vec().unwrap(), vec![20]);
+    assert_eq!(to_vec(&MyDiscriminantEnum::A).unwrap(), vec![20]);
 }
 
 #[test]
 fn test_discriminant_minimal_false() {
     assert_eq!(MyDiscriminantEnumFalse::A as u8, 20);
     assert_eq!(
-        MyEnumNoDiscriminant::A.try_to_vec().unwrap(),
-        MyDiscriminantEnumFalse::A.try_to_vec().unwrap(),
+        to_vec(&MyEnumNoDiscriminant::A).unwrap(),
+        to_vec(&MyDiscriminantEnumFalse::A).unwrap(),
     );
-    assert_eq!(MyDiscriminantEnumFalse::A.try_to_vec().unwrap(), vec![0]);
+    assert_eq!(to_vec(&MyDiscriminantEnumFalse::A).unwrap(), vec![0]);
 }
 
 // sequence
@@ -121,7 +121,7 @@ fn test_discriminant_serde_no_use_discriminant() {
     ];
     let expected_discriminants = [0u8, 1, 2, 3, 4, 5];
     for (index, value) in values.iter().enumerate() {
-        let data = value.try_to_vec().unwrap();
+        let data = to_vec(value).unwrap();
         assert_eq!(data[0], expected_discriminants[index]);
         assert_eq!(from_slice::<XNoDiscriminant>(&data).unwrap(), values[index]);
     }
@@ -155,7 +155,7 @@ enum X {
 fn test_discriminant_serialization() {
     let values = vec![X::A, X::B, X::C, X::D, X::E, X::F];
     for value in values {
-        assert_eq!(value.try_to_vec().unwrap(), [value as u8]);
+        assert_eq!(to_vec(&value).unwrap(), [value as u8]);
     }
 }
 
@@ -178,7 +178,7 @@ fn test_discriminant_serde() {
     let values = vec![X::A, X::B, X::C, X::D, X::E, X::F];
     let expected_discriminants = [0u8, 20, 21, 22, 10, 11];
     for (index, value) in values.iter().enumerate() {
-        let data = value.try_to_vec().unwrap();
+        let data = to_vec(value).unwrap();
         assert_eq!(data[0], expected_discriminants[index]);
         assert_eq!(from_slice::<X>(&data).unwrap(), values[index]);
     }

--- a/borsh/tests/test_generic_struct.rs
+++ b/borsh/tests/test_generic_struct.rs
@@ -23,7 +23,7 @@ use alloc::{
 #[cfg(not(feature = "std"))]
 use core::result::Result;
 
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 struct A<T, F, G> {
@@ -183,7 +183,7 @@ fn test_generic_struct() {
         c: Err("error".to_string()),
         d: [0, 1, 2, 3, 4],
     };
-    let data = a.try_to_vec().unwrap();
+    let data = to_vec(&a).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_a = from_slice::<A<String, u64, String>>(&data).unwrap();
@@ -196,7 +196,7 @@ fn test_generic_associated_type_field() {
         field: "value".to_string(),
         another: "field".to_string(),
     };
-    let data = a.try_to_vec().unwrap();
+    let data = to_vec(&a).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_a = from_slice::<Parametrized<u32, String>>(&data).unwrap();
@@ -213,7 +213,7 @@ fn test_generic_struct_hashmap() {
         a: "field".to_string(),
         b: hashmap,
     };
-    let data = a.try_to_vec().unwrap();
+    let data = to_vec(&a).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_a = from_slice::<C<u32, String>>(&data).unwrap();
@@ -229,7 +229,7 @@ fn test_generic_enum() {
     let c: B<String, u64> = B::Y(656556u64);
 
     let list = vec![b, c];
-    let data = list.try_to_vec().unwrap();
+    let data = to_vec(&list).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_list = from_slice::<Vec<B<String, u64>>>(&data).unwrap();

--- a/borsh/tests/test_init_in_deserialize.rs
+++ b/borsh/tests/test_init_in_deserialize.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg(feature = "derive")]
 
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 #[borsh(init=init)]
 struct A {
@@ -18,7 +18,8 @@ impl A {
 #[test]
 fn test_simple_struct() {
     let a = A { lazy: Some(5) };
-    let encoded_a = a.try_to_vec().unwrap();
+
+    let encoded_a = to_vec(&a).unwrap();
 
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(encoded_a);
@@ -45,7 +46,7 @@ impl AEnum {
 #[test]
 fn test_simple_enum() {
     let a = AEnum::B;
-    let encoded_a = a.try_to_vec().unwrap();
+    let encoded_a = to_vec(&a).unwrap();
 
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(encoded_a);

--- a/borsh/tests/test_primitives.rs
+++ b/borsh/tests/test_primitives.rs
@@ -1,12 +1,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use borsh::{from_slice, BorshSerialize};
+use borsh::{from_slice, to_vec};
 
 macro_rules! test_primitive {
     ($test_name: ident, $v: expr, $t: ty) => {
         #[test]
         fn $test_name() {
             let expected: $t = $v;
-            let buf = expected.try_to_vec().unwrap();
+
+            let buf = to_vec(&expected).unwrap();
             #[cfg(feature = "std")]
             insta::assert_debug_snapshot!(buf);
             let actual = from_slice::<$t>(&buf).expect("failed to deserialize");

--- a/borsh/tests/test_rc.rs
+++ b/borsh/tests/test_rc.rs
@@ -9,12 +9,12 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 pub use alloc::{rc, sync};
 
-use borsh::{from_slice, BorshSerialize};
+use borsh::{from_slice, to_vec};
 
 #[test]
 fn test_rc_roundtrip() {
     let value = rc::Rc::new(8u8);
-    let serialized = value.try_to_vec().unwrap();
+    let serialized = to_vec(&value).unwrap();
     let deserialized = from_slice::<rc::Rc<u8>>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }
@@ -23,7 +23,7 @@ fn test_rc_roundtrip() {
 fn test_slice_rc() {
     let original: &[i32] = &[1, 2, 3, 4, 6, 9, 10];
     let shared: rc::Rc<[i32]> = rc::Rc::from(original);
-    let serialized = shared.try_to_vec().unwrap();
+    let serialized = to_vec(&shared).unwrap();
     let deserialized = from_slice::<rc::Rc<[i32]>>(&serialized).unwrap();
     assert_eq!(original, &*deserialized);
 }
@@ -31,7 +31,7 @@ fn test_slice_rc() {
 #[test]
 fn test_arc_roundtrip() {
     let value = sync::Arc::new(8u8);
-    let serialized = value.try_to_vec().unwrap();
+    let serialized = to_vec(&value).unwrap();
     let deserialized = from_slice::<sync::Arc<u8>>(&serialized).unwrap();
     assert_eq!(value, deserialized);
 }
@@ -40,7 +40,7 @@ fn test_arc_roundtrip() {
 fn test_slice_arc() {
     let original: &[i32] = &[1, 2, 3, 4, 6, 9, 10];
     let shared: sync::Arc<[i32]> = sync::Arc::from(original);
-    let serialized = shared.try_to_vec().unwrap();
+    let serialized = to_vec(&shared).unwrap();
     let deserialized = from_slice::<sync::Arc<[i32]>>(&serialized).unwrap();
     assert_eq!(original, &*deserialized);
 }

--- a/borsh/tests/test_recursive_structs.rs
+++ b/borsh/tests/test_recursive_structs.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "derive")]
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 
 #[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
@@ -64,7 +64,8 @@ fn test_recursive_struct() {
         a: "three".to_string(),
         b: vec![one, two],
     };
-    let data = three.try_to_vec().unwrap();
+
+    let data = to_vec(&three).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_three = from_slice::<CRecB>(&data).unwrap();
@@ -80,7 +81,7 @@ fn test_recursive_enum() {
     let two = ERecD::C(10, vec![]);
 
     let three = ERecD::C(11, vec![one, two]);
-    let data = three.try_to_vec().unwrap();
+    let data = to_vec(&three).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
     let actual_three = from_slice::<ERecD>(&data).unwrap();

--- a/borsh/tests/test_ser_de_with.rs
+++ b/borsh/tests/test_ser_de_with.rs
@@ -11,7 +11,7 @@ use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
 };
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, PartialEq, Eq)]
 struct ThirdParty<K, V>(pub BTreeMap<K, V>);
@@ -87,7 +87,7 @@ fn test_overriden_struct() {
     let th_p = ThirdParty(m);
     let a = A { x: th_p, y: 42 };
 
-    let data = a.try_to_vec().unwrap();
+    let data = to_vec(&a).unwrap();
 
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);
@@ -103,7 +103,7 @@ fn test_overriden_enum() {
     let th_p = ThirdParty(m);
     let c = C::C4(42, th_p);
 
-    let data = c.try_to_vec().unwrap();
+    let data = to_vec(&c).unwrap();
 
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(data);

--- a/borsh/tests/test_simple_structs.rs
+++ b/borsh/tests/test_simple_structs.rs
@@ -26,7 +26,7 @@ use alloc::{
 
 use bytes::{Bytes, BytesMut};
 
-use borsh::{from_slice, BorshDeserialize, BorshSerialize};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 struct A<'a> {
@@ -127,9 +127,9 @@ fn test_ultimate_combined_all_features() {
         range_u32: 12..71,
         skipped: Some(6),
     };
-    let encoded_a = a.try_to_vec().unwrap();
+    let encoded_a = to_vec(&a).unwrap();
     let e = E { a: &a };
-    let encoded_ref_a = e.try_to_vec().unwrap();
+    let encoded_ref_a = to_vec(&e).unwrap();
     assert_eq!(encoded_ref_a, encoded_a);
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(encoded_a);
@@ -169,7 +169,7 @@ fn test_ultimate_combined_all_features() {
     assert_eq!(expected_a, decoded_a);
 
     let f1 = F1 { aa: &[&a, &a] };
-    let encoded_f1 = f1.try_to_vec().unwrap();
+    let encoded_f1 = to_vec(&f1).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(encoded_f1);
     let decoded_f2 = from_slice::<F2>(&encoded_f1).unwrap();

--- a/borsh/tests/test_strings.rs
+++ b/borsh/tests/test_strings.rs
@@ -4,14 +4,15 @@
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
-use borsh::{from_slice, BorshSerialize};
+use borsh::{from_slice, to_vec};
 
 macro_rules! test_string {
     ($test_name: ident, $str: expr, $snap: expr) => {
         #[test]
         fn $test_name() {
             let s = $str.to_string();
-            let buf = s.try_to_vec().unwrap();
+
+            let buf = to_vec(&s).unwrap();
             #[cfg(feature = "std")]
             if $snap {
                 insta::assert_debug_snapshot!(buf);

--- a/borsh/tests/test_tuple.rs
+++ b/borsh/tests/test_tuple.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use borsh::{from_slice, BorshSerialize};
+use borsh::{from_slice, to_vec};
 
 #[test]
 fn test_unary_tuple() {
     let expected = (true,);
-    let buf = expected.try_to_vec().unwrap();
+    let buf = to_vec(&expected).unwrap();
     #[cfg(feature = "std")]
     insta::assert_debug_snapshot!(buf);
     let actual = from_slice::<(bool,)>(&buf).expect("failed to deserialize");

--- a/borsh/tests/test_vecs.rs
+++ b/borsh/tests/test_vecs.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use borsh::{from_slice, BorshSerialize};
+use borsh::{from_slice, to_vec};
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -12,7 +12,7 @@ use alloc::{
 
 macro_rules! test_vec {
     ($v: expr, $t: ty, $snap: expr) => {
-        let buf = $v.try_to_vec().unwrap();
+        let buf = to_vec(&$v).unwrap();
         #[cfg(feature = "std")]
         if $snap {
             insta::assert_debug_snapshot!(buf);


### PR DESCRIPTION
Part of #51 resolution.

This pr addresses the following comment of [review](https://github.com/near/borsh-rs/issues/51#issuecomment-1684317118).
![tmp](https://github.com/near/borsh-rs/assets/26653921/09241a01-5f42-4300-8787-128c9082c7ae)


Logically this pr is part of #205 , but as the removal of this commonly used api caused moderate amout of changes, it was made a separate pr to be declined or approved separately from #205. 