### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.3...borsh-v1.0.0-alpha.4) - 2023-09-04
+
+### Added
+- [**breaking**] raise bound on keys in hashcollections `PartialOrd` -> `Ord` ([#203](https://github.com/near/borsh-rs/pull/203))
+- forbid most collections from containing zst elements/keys ([#202](https://github.com/near/borsh-rs/pull/202))
+- add `#[borsh(crate = ...)]` item-level attribute ([#210](https://github.com/near/borsh-rs/pull/210))
+- forbid multiple `borsh` attr occurencies ([#199](https://github.com/near/borsh-rs/pull/199))
+
+### Other
+- various flaws correction ([#205](https://github.com/near/borsh-rs/pull/205))
+- [**breaking**] deprecate `try_to_vec` method from `BorshSerialize` ([#206](https://github.com/near/borsh-rs/pull/206))
+- [**breaking**] make `BorshSchema::add_definition` default implementation a free-standing func ([#204](https://github.com/near/borsh-rs/pull/204))
+- remove `#[non_exhaustive]` on `borsh::schema::Definition` ([#200](https://github.com/near/borsh-rs/pull/200))
+
 ## [1.0.0-alpha.3](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.2...borsh-v1.0.0-alpha.3) - 2023-08-16
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["std", "derive", "schema"]
 cfg_aliases = "0.1.0"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.3", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.4", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get 


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `borsh-derive`: 1.0.0-alpha.3 -> 1.0.0-alpha.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.0.0-alpha.4](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.3...borsh-v1.0.0-alpha.4) - 2023-09-04

### Added
- [**breaking**] raise bound on keys in hashcollections `PartialOrd` -> `Ord` ([#203](https://github.com/near/borsh-rs/pull/203))
- forbid most collections from containing zst elements/keys ([#202](https://github.com/near/borsh-rs/pull/202))
- add `#[borsh(crate = ...)]` item-level attribute ([#210](https://github.com/near/borsh-rs/pull/210))
- forbid multiple `borsh` attr occurencies ([#199](https://github.com/near/borsh-rs/pull/199))

### Other
- various flaws correction ([#205](https://github.com/near/borsh-rs/pull/205))
- [**breaking**] deprecate `try_to_vec` method from `BorshSerialize` ([#206](https://github.com/near/borsh-rs/pull/206))
- [**breaking**] make `BorshSchema::add_definition` default implementation a free-standing func ([#204](https://github.com/near/borsh-rs/pull/204))
- remove `#[non_exhaustive]` on `borsh::schema::Definition` ([#200](https://github.com/near/borsh-rs/pull/200))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).