### PR TITLE
feat!: introduce `borsh::io` with either items of `std:io` or private `borsh::nostd_io` module reexported (`std` or `no_std`)

### DIFF
--- a/borsh-derive/src/internals/deserialize/enums/mod.rs
+++ b/borsh-derive/src/internals/deserialize/enums/mod.rs
@@ -34,21 +34,21 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
 
     Ok(quote! {
         impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-            fn deserialize_reader<R: #cratename::__private::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__private::maybestd::io::Error> {
+            fn deserialize_reader<R: #cratename::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::io::Error> {
                 let tag = <u8 as #cratename::de::BorshDeserialize>::deserialize_reader(reader)?;
                 <Self as #cratename::de::EnumExt>::deserialize_variant(reader, tag)
             }
         }
 
         impl #impl_generics #cratename::de::EnumExt for #name #ty_generics #where_clause {
-            fn deserialize_variant<R: #cratename::__private::maybestd::io::Read>(
+            fn deserialize_variant<R: #cratename::io::Read>(
                 reader: &mut R,
                 variant_tag: u8,
-            ) -> ::core::result::Result<Self, #cratename::__private::maybestd::io::Error> {
+            ) -> ::core::result::Result<Self, #cratename::io::Error> {
                 let mut return_value =
                     #variant_arms {
-                    return Err(#cratename::__private::maybestd::io::Error::new(
-                        #cratename::__private::maybestd::io::ErrorKind::InvalidData,
+                    return Err(#cratename::io::Error::new(
+                        #cratename::io::ErrorKind::InvalidData,
                         #cratename::__private::maybestd::format!("Unexpected variant tag: {:?}", variant_tag),
                     ))
                 };

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
@@ -3,18 +3,18 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for X {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
 impl borsh::de::EnumExt for X {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             X::A
         } else if variant_tag == 1u8 {
@@ -29,8 +29,8 @@ impl borsh::de::EnumExt for X {
             X::F
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
@@ -3,18 +3,18 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for X {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
 impl borsh::de::EnumExt for X {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0 {
             X::A
         } else if variant_tag == 20 {
@@ -29,8 +29,8 @@ impl borsh::de::EnumExt for X {
             X::F
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
@@ -3,18 +3,18 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for A {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
 impl borsh::de::EnumExt for A {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::A
         } else if variant_tag == 1u8 {
@@ -29,8 +29,8 @@ impl borsh::de::EnumExt for A {
             A::F
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -3,18 +3,18 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for AA {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
 impl borsh::de::EnumExt for AA {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             AA::B {
                 c: core::default::Default::default(),
@@ -26,8 +26,8 @@ impl borsh::de::EnumExt for AA {
             }
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -3,18 +3,18 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for AAT {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
 impl borsh::de::EnumExt for AAT {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             AAT::B(
                 core::default::Default::default(),
@@ -26,8 +26,8 @@ impl borsh::de::EnumExt for AAT {
             }
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
@@ -9,9 +9,9 @@ where
     V: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -23,10 +23,10 @@ where
     V: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -39,8 +39,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
@@ -7,9 +7,9 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -19,10 +19,10 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             C::C3(
                 borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -35,8 +35,8 @@ where
             }
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -10,9 +10,9 @@ where
     K: core::default::Default,
     V: core::default::Default,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -25,10 +25,10 @@ where
     K: core::default::Default,
     V: core::default::Default,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: core::default::Default::default(),
@@ -41,8 +41,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -9,9 +9,9 @@ where
     V: borsh::de::BorshDeserialize,
     U: core::default::Default,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -23,10 +23,10 @@ where
     V: borsh::de::BorshDeserialize,
     U: core::default::Default,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -39,8 +39,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
@@ -7,9 +7,9 @@ where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -19,10 +19,10 @@ where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::C {
                 a: borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -35,8 +35,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
@@ -8,9 +8,9 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -21,10 +21,10 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -37,8 +37,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -3,12 +3,9 @@ source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::de::BorshDeserialize for A {
-    fn deserialize_reader<R: reexporter::borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: reexporter::borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<
-        Self,
-        reexporter::borsh::__private::maybestd::io::Error,
-    > {
+    ) -> ::core::result::Result<Self, reexporter::borsh::io::Error> {
         let tag = <u8 as reexporter::borsh::de::BorshDeserialize>::deserialize_reader(
             reader,
         )?;
@@ -16,13 +13,10 @@ impl reexporter::borsh::de::BorshDeserialize for A {
     }
 }
 impl reexporter::borsh::de::EnumExt for A {
-    fn deserialize_variant<R: reexporter::borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: reexporter::borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<
-        Self,
-        reexporter::borsh::__private::maybestd::io::Error,
-    > {
+    ) -> ::core::result::Result<Self, reexporter::borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -35,8 +29,8 @@ impl reexporter::borsh::de::EnumExt for A {
             )
         } else {
             return Err(
-                reexporter::borsh::__private::maybestd::io::Error::new(
-                    reexporter::borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                reexporter::borsh::io::Error::new(
+                    reexporter::borsh::io::ErrorKind::InvalidData,
                     reexporter::borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
@@ -8,9 +8,9 @@ where
     V: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let tag = <u8 as borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
@@ -21,10 +21,10 @@ where
     V: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_variant<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_variant<R: borsh::io::Read>(
         reader: &mut R,
         variant_tag: u8,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = if variant_tag == 0u8 {
             A::B {
                 x: borsh::BorshDeserialize::deserialize_reader(reader)?,
@@ -37,8 +37,8 @@ where
             )
         } else {
             return Err(
-                borsh::__private::maybestd::io::Error::new(
-                    borsh::__private::maybestd::io::ErrorKind::InvalidData,
+                borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
                         "Unexpected variant tag: {:?}", variant_tag
                     ),

--- a/borsh-derive/src/internals/deserialize/structs/mod.rs
+++ b/borsh-derive/src/internals/deserialize/structs/mod.rs
@@ -40,7 +40,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
     if let Some(method_ident) = item::contains_initialize_with(&input.attrs)? {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize_reader<R: #cratename::__private::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__private::maybestd::io::Error> {
+                fn deserialize_reader<R: #cratename::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::io::Error> {
                     let mut return_value = #return_value;
                     return_value.#method_ident();
                     Ok(return_value)
@@ -50,7 +50,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
     } else {
         Ok(quote! {
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
-                fn deserialize_reader<R: #cratename::__private::maybestd::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::__private::maybestd::io::Error> {
+                fn deserialize_reader<R: #cratename::io::Read>(reader: &mut R) -> ::core::result::Result<Self, #cratename::io::Error> {
                     Ok(#return_value)
                 }
             }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
@@ -3,9 +3,9 @@ source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for A {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = Self {
             x: borsh::BorshDeserialize::deserialize_reader(reader)?,
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
@@ -8,9 +8,9 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             x: borsh::BorshDeserialize::deserialize_reader(reader)?,
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
@@ -7,9 +7,9 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             x: third_party_impl::deserialize_third_party(reader)?,
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
@@ -7,9 +7,9 @@ where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             a: borsh::BorshDeserialize::deserialize_reader(reader)?,
             b: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -8,9 +8,9 @@ where
     K: core::default::Default,
     V: core::default::Default,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             x: core::default::Default::default(),
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -8,9 +8,9 @@ where
     K: core::default::Default,
     V: core::default::Default,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(
             Self(
                 core::default::Default::default(),

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -8,9 +8,9 @@ where
     V: borsh::de::BorshDeserialize,
     U: core::default::Default,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(
             Self(
                 borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
@@ -6,9 +6,9 @@ impl<K, V, U> borsh::de::BorshDeserialize for G1<K, V, U>
 where
     U: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(
             Self(
                 core::default::Default::default(),

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
@@ -3,9 +3,9 @@ source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for CRecC {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             a: borsh::BorshDeserialize::deserialize_reader(reader)?,
             b: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -6,9 +6,9 @@ impl<T> borsh::de::BorshDeserialize for TupleA<T>
 where
     T: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(
             Self(
                 borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
@@ -7,9 +7,9 @@ where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
 {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             x: borsh::BorshDeserialize::deserialize_reader(reader)?,
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
@@ -3,9 +3,9 @@ source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::de::BorshDeserialize for A {
-    fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<Self, borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<Self, borsh::io::Error> {
         Ok(Self {
             x: borsh::BorshDeserialize::deserialize_reader(reader)?,
             y: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -3,12 +3,9 @@ source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::de::BorshDeserialize for A {
-    fn deserialize_reader<R: reexporter::borsh::__private::maybestd::io::Read>(
+    fn deserialize_reader<R: reexporter::borsh::io::Read>(
         reader: &mut R,
-    ) -> ::core::result::Result<
-        Self,
-        reexporter::borsh::__private::maybestd::io::Error,
-    > {
+    ) -> ::core::result::Result<Self, reexporter::borsh::io::Error> {
         Ok(Self {
             x: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
             y: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/borsh-derive/src/internals/serialize/enums/mod.rs
+++ b/borsh-derive/src/internals/serialize/enums/mod.rs
@@ -41,7 +41,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
 
     Ok(quote! {
         impl #impl_generics #cratename::ser::BorshSerialize for #enum_ident #ty_generics #where_clause {
-            fn serialize<W: #cratename::__private::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::__private::maybestd::io::Error> {
+            fn serialize<W: #cratename::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::io::Error> {
                 let variant_idx: u8 = match self {
                     #all_variants_idx_body
                 };

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for X {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             X::A => 0u8,
             X::B => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for X {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             X::A => 0,
             X::B => 20,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for AAB {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             AAB::B { .. } => 0u8,
             AAB::NegatedVariant { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for AB {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             AB::B { .. } => 0u8,
             AB::NegatedVariant { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for AATTB {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             AATTB::B(..) => 0u8,
             AATTB::NegatedVariant { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
@@ -9,10 +9,10 @@ where
     V: borsh::ser::BorshSerialize,
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::B { .. } => 0u8,
             A::C(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
@@ -7,10 +7,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             C::C3(..) => 0u8,
             C::C4 { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -8,10 +8,10 @@ where
     K: borsh::ser::BorshSerialize,
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::B { .. } => 0u8,
             A::C(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -8,10 +8,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::B { .. } => 0u8,
             A::C(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
@@ -7,10 +7,10 @@ where
     T: borsh::ser::BorshSerialize + PartialOrd,
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::C { .. } => 0u8,
             A::D(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
@@ -8,10 +8,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::B { .. } => 0u8,
             A::C(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::ser::BorshSerialize for AB {
-    fn serialize<W: reexporter::borsh::__private::maybestd::io::Write>(
+    fn serialize<W: reexporter::borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), reexporter::borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), reexporter::borsh::io::Error> {
         let variant_idx: u8 = match self {
             AB::B { .. } => 0u8,
             AB::NegatedVariant { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
@@ -8,10 +8,10 @@ where
     V: borsh::ser::BorshSerialize,
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             A::B { .. } => 0u8,
             A::C(..) => 1u8,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for AB {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let variant_idx: u8 = match self {
             AB::B { .. } => 0u8,
             AB::NegatedVariant { .. } => 1u8,

--- a/borsh-derive/src/internals/serialize/structs/mod.rs
+++ b/borsh-derive/src/internals/serialize/structs/mod.rs
@@ -35,7 +35,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
 
     Ok(quote! {
         impl #impl_generics #cratename::ser::BorshSerialize for #name #ty_generics #where_clause {
-            fn serialize<W: #cratename::__private::maybestd::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::__private::maybestd::io::Error> {
+            fn serialize<W: #cratename::io::Write>(&self, writer: &mut W) -> ::core::result::Result<(), #cratename::io::Error> {
                 #body
                 Ok(())
             }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
@@ -8,10 +8,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
@@ -7,10 +7,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         third_party_impl::serialize_third_party(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
@@ -8,10 +8,10 @@ where
     T::Associated: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.field, writer)?;
         borsh::BorshSerialize::serialize(&self.another, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -6,10 +6,10 @@ impl<K, V, U> borsh::ser::BorshSerialize for G<K, V, U>
 where
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())
     }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
@@ -7,10 +7,10 @@ where
     T: borsh::ser::BorshSerialize + PartialOrd,
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.a, writer)?;
         borsh::BorshSerialize::serialize(&self.b, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -6,10 +6,10 @@ impl<K, V, U> borsh::ser::BorshSerialize for G<K, V, U>
 where
     U: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.1, writer)?;
         Ok(())
     }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -7,10 +7,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.0, writer)?;
         Ok(())
     }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
@@ -8,10 +8,10 @@ where
     V: borsh::ser::BorshSerialize,
     <T as TraitName>::Associated: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.field, writer)?;
         borsh::BorshSerialize::serialize(&self.another, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for CRecC {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.a, writer)?;
         borsh::BorshSerialize::serialize(&self.b, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -6,10 +6,10 @@ impl<T> borsh::ser::BorshSerialize for TupleA<T>
 where
     T: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.0, writer)?;
         borsh::BorshSerialize::serialize(&self.1, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
@@ -7,10 +7,10 @@ where
     K: borsh::ser::BorshSerialize,
     V: borsh::ser::BorshSerialize,
 {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::ser::BorshSerialize for A {
-    fn serialize<W: borsh::__private::maybestd::io::Write>(
+    fn serialize<W: borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -3,10 +3,10 @@ source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::ser::BorshSerialize for A {
-    fn serialize<W: reexporter::borsh::__private::maybestd::io::Write>(
+    fn serialize<W: reexporter::borsh::io::Write>(
         &self,
         writer: &mut W,
-    ) -> ::core::result::Result<(), reexporter::borsh::__private::maybestd::io::Error> {
+    ) -> ::core::result::Result<(), reexporter::borsh::io::Error> {
         reexporter::borsh::BorshSerialize::serialize(&self.x, writer)?;
         reexporter::borsh::BorshSerialize::serialize(&self.y, writer)?;
         Ok(())

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -257,16 +257,15 @@ use indexmap::IndexMap;
 mod index_map_impl {
     use super::IndexMap;
     use core::hash::Hash;
-    use std::io;
 
     pub fn serialize_index_map<
         K: borsh::ser::BorshSerialize,
         V: borsh::ser::BorshSerialize,
-        W: io::Write,
+        W: borsh::io::Write,
     >(
         obj: &IndexMap<K, V>,
         writer: &mut W,
-    ) -> ::core::result::Result<(), io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         let key_value_tuples = obj.iter().collect::<Vec<_>>();
         borsh::BorshSerialize::serialize(&key_value_tuples, writer)?;
         Ok(())
@@ -599,15 +598,14 @@ use indexmap::IndexMap;
 mod index_map_impl {
     use super::IndexMap;
     use core::hash::Hash;
-    use std::io;
 
     pub fn deserialize_index_map<
-        R: io::Read,
+        R: borsh::io::Read,
         K: borsh::de::BorshDeserialize + Hash + Eq,
         V: borsh::de::BorshDeserialize,
     >(
         reader: &mut R,
-    ) -> ::core::result::Result<IndexMap<K, V>, io::Error> {
+    ) -> ::core::result::Result<IndexMap<K, V>, borsh::io::Error> {
         let vec: Vec<(K, V)> = borsh::BorshDeserialize::deserialize_reader(reader)?;
         let result: IndexMap<K, V> = vec.into_iter().collect();
         Ok(result)

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -13,11 +13,11 @@ use crate::__private::maybestd::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
     format,
-    io::{Error, ErrorKind, Read, Result},
     string::{String, ToString},
     vec,
     vec::Vec,
 };
+use crate::io::{Error, ErrorKind, Read, Result};
 
 #[cfg(feature = "rc")]
 use crate::__private::maybestd::{rc::Rc, sync::Arc};
@@ -105,14 +105,14 @@ pub trait EnumExt: BorshDeserialize {
     ///
     /// # #[cfg(feature = "derive")]
     /// impl borsh::de::BorshDeserialize for OneOrZero {
-    ///     fn deserialize_reader<R: borsh::__private::maybestd::io::Read>(
+    ///     fn deserialize_reader<R: borsh::io::Read>(
     ///         reader: &mut R,
-    ///     ) -> borsh::__private::maybestd::io::Result<Self> {
+    ///     ) -> borsh::io::Result<Self> {
     ///         use borsh::de::EnumExt;
     ///         let tag = u8::deserialize_reader(reader)?;
     ///         if tag == 2 {
-    ///             Err(borsh::__private::maybestd::io::Error::new(
-    ///                 borsh::__private::maybestd::io::ErrorKind::InvalidData,
+    ///             Err(borsh::io::Error::new(
+    ///                 borsh::io::ErrorKind::InvalidData,
     ///                 "MyEnum::Many not allowed here",
     ///             ))
     ///         } else {
@@ -476,20 +476,20 @@ where
 #[cfg(hash_collections)]
 pub mod hashes {
     //!
-    //! Module defines [BorshDeserialize](crate::de::BorshDeserialize) implementation for  
+    //! Module defines [BorshDeserialize](crate::de::BorshDeserialize) implementation for
     //! [HashMap](std::collections::HashMap)/[HashSet](std::collections::HashSet).
     use core::hash::{BuildHasher, Hash};
 
     use crate::BorshDeserialize;
     use crate::__private::maybestd::collections::{HashMap, HashSet};
-    use crate::__private::maybestd::io::{Read, Result};
     use crate::__private::maybestd::vec::Vec;
+    use crate::io::{Read, Result};
 
     #[cfg(feature = "de_strict_order")]
     const ERROR_WRONG_ORDER_OF_KEYS: &str = "keys were not serialized in ascending order";
-    #[cfg(feature = "de_strict_order")]
-    use crate::__private::maybestd::io::{Error, ErrorKind};
     use crate::error::check_zst;
+    #[cfg(feature = "de_strict_order")]
+    use crate::io::{Error, ErrorKind};
 
     impl<T, H> BorshDeserialize for HashSet<T, H>
     where

--- a/borsh/src/error.rs
+++ b/borsh/src/error.rs
@@ -1,4 +1,4 @@
-use crate::__private::maybestd::io::{Error, ErrorKind, Result};
+use crate::io::{Error, ErrorKind, Result};
 use core::mem::size_of;
 pub const ERROR_ZST_FORBIDDEN: &str = "Collections of zero-sized types are not allowed due to deny-of-service concerns on deserialization.";
 

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -7,14 +7,16 @@
 ### Ecosystem features
 
 * **std** -
-  When enabled, this will cause `borsh` to use the standard library. Currently,
-  disabling this feature will result in building the crate in `no_std` environment.
+  When enabled, `borsh` uses the standard library. Disabling this feature will
+  result in building the crate in `no_std` environment.
 
-  Borsh has `nostd_io` module when compiled with **std** disabled. It contains a few items,
-  counterparts of `std::io` items,
-  which are used in [BorshSerialize](crate::ser::BorshSerialize) and [BorshDeserialize](crate::de::BorshDeserialize)
-  traits' definitions in absence of `std`. Most prominent of them are `borsh::nostd_io::Read` and `borsh::nostd_io::Write` traits.
+  To carter such builds, Borsh offers [`io`] module which includes a items which
+  are used in [`BorshSerialize`] and [`BorshDeserialize`] traits.  Most notably
+  `io::Read`, `io::Write` and `io::Result`.
 
+  When **std** feature is enabled, those items are re-exports of corresponding
+  `std::io` items.  Otherwise they are borsh-specific types which mimic
+  behaviour of corresponding standard types.
 
 ### Default features
 
@@ -100,8 +102,21 @@ pub mod error;
 #[cfg(all(feature = "std", feature = "hashbrown"))]
 compile_error!("feature \"std\" and feature \"hashbrown\" don't make sense at the same time");
 
+#[cfg(feature = "std")]
+use std::io as io_impl;
 #[cfg(not(feature = "std"))]
-pub mod nostd_io;
+mod nostd_io;
+#[cfg(not(feature = "std"))]
+use nostd_io as io_impl;
+
+/// Subset of `std::io` which is used as part of borsh public API.
+///
+/// When crate is built with `std` feature disabled (it’s enabled by default),
+/// the exported types are custom borsh types which try to mimic behaviour of
+/// corresponding standard types usually offering subset of features.
+pub mod io {
+    pub use super::io_impl::{Error, ErrorKind, Read, Result, Write};
+}
 
 #[doc(hidden)]
 pub mod __private {
@@ -111,7 +126,7 @@ pub mod __private {
     /// module.
     #[cfg(feature = "std")]
     pub mod maybestd {
-        pub use std::{borrow, boxed, collections, format, io, string, vec};
+        pub use std::{borrow, boxed, collections, format, string, vec};
 
         #[cfg(feature = "rc")]
         pub use std::{rc, sync};

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -143,9 +143,5 @@ pub mod __private {
             #[cfg(feature = "hashbrown")]
             pub use hashbrown::*;
         }
-
-        pub mod io {
-            pub use crate::nostd_io::*;
-        }
     }
 }

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -13,15 +13,15 @@
 
 #![allow(dead_code)] // Unclear why rust check complains on fields of `Definition` variants.
 use crate as borsh; // For `#[derive(BorshSerialize, BorshDeserialize)]`.
-use crate::__private::maybestd::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 use crate::__private::maybestd::{
     boxed::Box,
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
     format,
-    io::{Read, Result as IOResult, Write},
     string::{String, ToString},
     vec,
     vec::Vec,
 };
+use crate::io::{Read, Result as IOResult, Write};
 use crate::{BorshDeserialize, BorshSchema as BorshSchemaMacro, BorshSerialize};
 use core::borrow::Borrow;
 use core::cmp::Ord;

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -1,8 +1,6 @@
-use crate::__private::maybestd::{
-    io::{Error, ErrorKind, Result},
-    vec::Vec,
-};
+use crate::__private::maybestd::vec::Vec;
 use crate::from_slice;
+use crate::io::{Error, ErrorKind, Result};
 use crate::schema::{BorshSchemaContainer, Declaration, Definition, Fields};
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
 

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,8 +1,6 @@
 use crate::BorshSerialize;
-use crate::__private::maybestd::{
-    io::{Result, Write},
-    vec::Vec,
-};
+use crate::__private::maybestd::vec::Vec;
+use crate::io::{Result, Write};
 
 pub(super) const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
 

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -1,17 +1,15 @@
 use core::convert::TryFrom;
 use core::marker::PhantomData;
 
-use crate::{
-    __private::maybestd::{
-        borrow::{Cow, ToOwned},
-        boxed::Box,
-        collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
-        io::{Error, ErrorKind, Result, Write},
-        string::String,
-        vec::Vec,
-    },
-    error::check_zst,
+use crate::__private::maybestd::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
+    string::String,
+    vec::Vec,
 };
+use crate::error::check_zst;
+use crate::io::{Error, ErrorKind, Result, Write};
 
 #[cfg(feature = "rc")]
 use crate::__private::maybestd::{rc::Rc, sync::Arc};
@@ -349,7 +347,7 @@ where
 #[cfg(hash_collections)]
 pub mod hashes {
     //!
-    //! Module defines [BorshSerialize](crate::ser::BorshSerialize) implementation for  
+    //! Module defines [BorshSerialize](crate::ser::BorshSerialize) implementation for
     //! [HashMap](std::collections::HashMap)/[HashSet](std::collections::HashSet).
     use crate::__private::maybestd::vec::Vec;
     use crate::error::check_zst;
@@ -360,7 +358,7 @@ pub mod hashes {
     use core::convert::TryFrom;
     use core::hash::BuildHasher;
 
-    use crate::__private::maybestd::io::{ErrorKind, Result, Write};
+    use crate::io::{ErrorKind, Result, Write};
 
     impl<K, V, H> BorshSerialize for HashMap<K, V, H>
     where

--- a/borsh/tests/test_custom_reader.rs
+++ b/borsh/tests/test_custom_reader.rs
@@ -10,12 +10,6 @@ use alloc::{
     vec::Vec,
 };
 
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(not(feature = "std"))]
-use borsh::nostd_io as io;
-
 const ERROR_NOT_ALL_BYTES_READ: &str = "Not all bytes read";
 const ERROR_UNEXPECTED_LENGTH_OF_INPUT: &str = "Unexpected length of input";
 
@@ -91,8 +85,8 @@ struct CustomReader {
     read_index: usize,
 }
 
-impl io::Read for CustomReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+impl borsh::io::Read for CustomReader {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::io::Result<usize> {
         let len = buf.len().min(self.data.len() - self.read_index);
         buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
         self.read_index += len;
@@ -123,8 +117,8 @@ struct CustomReaderThatDoesntFillSlices {
     read_index: usize,
 }
 
-impl io::Read for CustomReaderThatDoesntFillSlices {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+impl borsh::io::Read for CustomReaderThatDoesntFillSlices {
+    fn read(&mut self, buf: &mut [u8]) -> borsh::io::Result<usize> {
         let len = buf.len().min(self.data.len() - self.read_index);
         let len = if len <= 1 { len } else { len / 2 };
         buf[0..len].copy_from_slice(&self.data[self.read_index..self.read_index + len]);
@@ -139,15 +133,15 @@ fn test_custom_reader_that_fails_preserves_error_information() {
 
     let err = from_reader::<CustomReaderThatFails, Serializable>(&mut reader).unwrap_err();
     assert_eq!(err.to_string(), "I don't like to run");
-    assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+    assert_eq!(err.kind(), borsh::io::ErrorKind::ConnectionAborted);
 }
 
 struct CustomReaderThatFails;
 
-impl io::Read for CustomReaderThatFails {
-    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::new(
-            io::ErrorKind::ConnectionAborted,
+impl borsh::io::Read for CustomReaderThatFails {
+    fn read(&mut self, _buf: &mut [u8]) -> borsh::io::Result<usize> {
+        Err(borsh::io::Error::new(
+            borsh::io::ErrorKind::ConnectionAborted,
             "I don't like to run",
         ))
     }

--- a/borsh/tests/test_ser_de_with.rs
+++ b/borsh/tests/test_ser_de_with.rs
@@ -19,30 +19,25 @@ struct ThirdParty<K, V>(pub BTreeMap<K, V>);
 mod third_party_impl {
     use super::ThirdParty;
 
-    #[cfg(feature = "std")]
-    use std::io;
-
-    #[cfg(not(feature = "std"))]
-    use borsh::nostd_io as io;
     pub(super) fn serialize_third_party<
         K: borsh::ser::BorshSerialize,
         V: borsh::ser::BorshSerialize,
-        W: io::Write,
+        W: borsh::io::Write,
     >(
         obj: &ThirdParty<K, V>,
         writer: &mut W,
-    ) -> ::core::result::Result<(), io::Error> {
+    ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&obj.0, writer)?;
         Ok(())
     }
 
     pub(super) fn deserialize_third_party<
-        R: io::Read,
+        R: borsh::io::Read,
         K: borsh::de::BorshDeserialize + Ord,
         V: borsh::de::BorshDeserialize,
     >(
         reader: &mut R,
-    ) -> ::core::result::Result<ThirdParty<K, V>, io::Error> {
+    ) -> ::core::result::Result<ThirdParty<K, V>, borsh::io::Error> {
         Ok(ThirdParty(borsh::BorshDeserialize::deserialize_reader(
             reader,
         )?))


### PR DESCRIPTION
When built with `std` feature, borsh uses a handful of std::io types
in its public API (e.g. std::io::Write is used in BorshSerialize
trait).  When `std` feature is disabled, borsh switches to its own
types which mimics behaviour of standard types offered through
`borsh::nostd_io`.

Problem is that this approach results in no consistent way to name
`Write`, `Read` etc. symbols used in the public API.  This creates
a problem for authors and users of no_std libraries.  A no_std library
might have code such as:

    impl borsh::BorshSerialize for Foo {
        fn serialize<W: borsh::nostd_io::Write>(
            &self, writer: &mut W,
        ) -> borsh::maybestd::io::Result<()> {
            todo!()
        }
    }

So long as borsh is built with default features disabled it will work
correctly.  However, if author of a std application enables borsh’s
std feature, the aforementioned example crate will fail to build since
borsh::nostd_io will no longer be offered.

Address this by introducing `borsh::io` module which exports Error,
ErrorKind, Read, Result and Write symbols, i.e. the types which are
used in borsh’s public API.

With this change, author of a no_std library may write:

    impl borsh::BorshSerialize for Foo {
        fn serialize<W: borsh::io::Write>(
            &self, writer: &mut W,
        ) -> borsh::maybestd::io::Result<()> {
            todo!()
        }
    }

and their code will work without problems when used in std
applications.
