### PR TITLE
feat: add `BorshSchema` implementation for `core::num::NonZero...` integers

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -289,17 +289,18 @@ impl_for_renamed_primitives!(str: string);
 impl_for_renamed_primitives!(isize: i64);
 impl_for_renamed_primitives!(usize: u64);
 
-impl_for_renamed_primitives!(core::num::NonZeroI8: i8);
-impl_for_renamed_primitives!(core::num::NonZeroI16: i16);
-impl_for_renamed_primitives!(core::num::NonZeroI32: i32);
-impl_for_renamed_primitives!(core::num::NonZeroI64: i64);
-impl_for_renamed_primitives!(core::num::NonZeroI128: i128);
-impl_for_renamed_primitives!(core::num::NonZeroU8: u8);
-impl_for_renamed_primitives!(core::num::NonZeroU16: u16);
-impl_for_renamed_primitives!(core::num::NonZeroU32: u32);
-impl_for_renamed_primitives!(core::num::NonZeroU64: u64);
-impl_for_renamed_primitives!(core::num::NonZeroU128: u128);
-impl_for_renamed_primitives!(core::num::NonZeroUsize: usize);
+impl_for_renamed_primitives!(core::num::NonZeroI8: nonzero_i8);
+impl_for_renamed_primitives!(core::num::NonZeroI16: nonzero_i16);
+impl_for_renamed_primitives!(core::num::NonZeroI32: nonzero_i32);
+impl_for_renamed_primitives!(core::num::NonZeroI64: nonzero_i64);
+impl_for_renamed_primitives!(core::num::NonZeroI128: nonzero_i128);
+impl_for_renamed_primitives!(core::num::NonZeroU8: nonzero_u8);
+impl_for_renamed_primitives!(core::num::NonZeroU16: nonzero_u16);
+impl_for_renamed_primitives!(core::num::NonZeroU32: nonzero_u32);
+impl_for_renamed_primitives!(core::num::NonZeroU64: nonzero_u64);
+impl_for_renamed_primitives!(core::num::NonZeroU128: nonzero_u128);
+// see 12 lines above
+impl_for_renamed_primitives!(core::num::NonZeroUsize: nonzero_u64);
 
 impl<T, const N: usize> BorshSchema for [T; N]
 where
@@ -640,13 +641,13 @@ mod tests {
         let actual_name = <(u64, core::num::NonZeroU16, String)>::declaration();
         let mut actual_defs = map!();
         <(u64, core::num::NonZeroU16, String)>::add_definitions_recursively(&mut actual_defs);
-        assert_eq!("Tuple<u64, u16, string>", actual_name);
+        assert_eq!("Tuple<u64, nonzero_u16, string>", actual_name);
         assert_eq!(
             map! {
-                "Tuple<u64, u16, string>" => Definition::Tuple {
+                "Tuple<u64, nonzero_u16, string>" => Definition::Tuple {
                     elements: vec![
                         "u64".to_string(),
-                        "u16".to_string(),
+                        "nonzero_u16".to_string(),
                         "string".to_string()
                     ]
                 }

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -234,7 +234,7 @@ impl BorshSchema for () {
 }
 
 macro_rules! impl_for_renamed_primitives {
-    ($($type: ident : $name: ident)+) => {
+    ($($type: ty : $name: ident)+) => {
     $(
         impl BorshSchema for $type {
             fn add_definitions_recursively(_definitions: &mut BTreeMap<Declaration, Definition>) {}
@@ -257,6 +257,18 @@ impl_for_renamed_primitives!(String: string);
 impl_for_renamed_primitives!(str: string);
 impl_for_renamed_primitives!(isize: i64);
 impl_for_renamed_primitives!(usize: u64);
+
+impl_for_renamed_primitives!(core::num::NonZeroI8: i8);
+impl_for_renamed_primitives!(core::num::NonZeroI16: i16);
+impl_for_renamed_primitives!(core::num::NonZeroI32: i32);
+impl_for_renamed_primitives!(core::num::NonZeroI64: i64);
+impl_for_renamed_primitives!(core::num::NonZeroI128: i128);
+impl_for_renamed_primitives!(core::num::NonZeroU8: u8);
+impl_for_renamed_primitives!(core::num::NonZeroU16: u16);
+impl_for_renamed_primitives!(core::num::NonZeroU32: u32);
+impl_for_renamed_primitives!(core::num::NonZeroU64: u64);
+impl_for_renamed_primitives!(core::num::NonZeroU128: u128);
+impl_for_renamed_primitives!(core::num::NonZeroUsize: usize);
 
 impl<T, const N: usize> BorshSchema for [T; N]
 where
@@ -585,13 +597,19 @@ mod tests {
 
     #[test]
     fn simple_tuple() {
-        let actual_name = <(u64, String)>::declaration();
+        let actual_name = <(u64, core::num::NonZeroU16, String)>::declaration();
         let mut actual_defs = map!();
-        <(u64, String)>::add_definitions_recursively(&mut actual_defs);
-        assert_eq!("Tuple<u64, string>", actual_name);
+        <(u64, core::num::NonZeroU16, String)>::add_definitions_recursively(&mut actual_defs);
+        assert_eq!("Tuple<u64, u16, string>", actual_name);
         assert_eq!(
             map! {
-                "Tuple<u64, string>" => Definition::Tuple { elements: vec![ "u64".to_string(), "string".to_string()]}
+                "Tuple<u64, u16, string>" => Definition::Tuple {
+                    elements: vec![
+                        "u64".to_string(),
+                        "u16".to_string(),
+                        "string".to_string()
+                    ]
+                }
             },
             actual_defs
         );

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -225,11 +225,11 @@ fn max_serialized_size_impl<'a>(
 
         // Primitive types.
         Err("nil") => Ok(0),
-        Err("bool" | "i8" | "u8") => Ok(count),
-        Err("i16" | "u16") => mul(count, 2),
-        Err("i32" | "u32" | "f32") => mul(count, 4),
-        Err("i64" | "u64" | "f64") => mul(count, 8),
-        Err("i128" | "u128") => mul(count, 16),
+        Err("bool" | "i8" | "u8" | "nonzero_i8" | "nonzero_u8") => Ok(count),
+        Err("i16" | "u16" | "nonzero_i16" | "nonzero_u16") => mul(count, 2),
+        Err("i32" | "u32" | "f32" | "nonzero_i32" | "nonzero_u32") => mul(count, 4),
+        Err("i64" | "u64" | "f64" | "nonzero_i64" | "nonzero_u64") => mul(count, 8),
+        Err("i128" | "u128" | "nonzero_i128" | "nonzero_u128") => mul(count, 16),
 
         // string is just Vec<u8>
         Err("string") => mul(count, add(MAX_LEN, 4)?),
@@ -277,6 +277,9 @@ mod tests {
     fn max_serialized_size_built_in_types() {
         test_ok::<u16>(2);
         test_ok::<usize>(8);
+
+        test_ok::<core::num::NonZeroI16>(2);
+        test_ok::<core::num::NonZeroU32>(4);
 
         test_ok::<Option<()>>(1);
         test_ok::<Option<u8>>(2);


### PR DESCRIPTION
appears to be continuation of #66 