### PR TITLE
Add Definition::Enum::tag_width field

### DIFF
--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -53,8 +53,10 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
         fn add_definitions_recursively(definitions: &mut #cratename::__private::maybestd::collections::BTreeMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
             #inner_defs
             #add_recursive_defs
-            let variants = #cratename::__private::maybestd::vec![#(#variants_defs),*];
-            let definition = #cratename::schema::Definition::Enum{variants};
+            let definition = #cratename::schema::Definition::Enum {
+                tag_width: 1,
+                variants: #cratename::__private::maybestd::vec![#(#variants_defs),*],
+            };
             #cratename::schema::add_definition(Self::declaration(), definition, definitions);
         }
     };

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -35,13 +35,13 @@ impl borsh::BorshSchema for A {
         <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration()), ("Salad".to_string(), < ASalad > ::declaration()),
-            ("Sausage".to_string(), < ASausage > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration()), ("Salad".to_string(), < ASalad >
+                ::declaration()), ("Sausage".to_string(), < ASausage > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -42,13 +42,14 @@ where
         <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
-            ::declaration()), ("Sausage".to_string(), < ASausage < W > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
+                ::declaration()), ("Sausage".to_string(), < ASausage < W > >
+                ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -44,14 +44,14 @@ where
         <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASausage<W, U> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
-            ::declaration()), ("Sausage".to_string(), < ASausage < W, U > >
-            ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
+                ::declaration()), ("Sausage".to_string(), < ASausage < W, U > >
+                ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -43,13 +43,14 @@ where
         <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
-            ::declaration()), ("Sausage".to_string(), < ASausage < W > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration()), ("Salad".to_string(), < ASalad < C > >
+                ::declaration()), ("Sausage".to_string(), < ASausage < W > >
+                ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -29,12 +29,12 @@ impl borsh::BorshSchema for A {
         }
         <AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("B".to_string(), < AB > ::declaration()), ("Negative".to_string(), <
-            ANegative > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("B".to_string(), < AB > ::declaration()), ("Negative".to_string(), <
+                ANegative > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -55,12 +55,12 @@ where
         <EnumParametrizedC<
             T,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("B".to_string(), < EnumParametrizedB < K, V > > ::declaration()), ("C"
-            .to_string(), < EnumParametrizedC < T > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("B".to_string(), < EnumParametrizedB < K, V > > ::declaration()), ("C"
+                .to_string(), < EnumParametrizedC < T > > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -56,12 +56,12 @@ where
         <EnumParametrizedC<
             T,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("B".to_string(), < EnumParametrizedB < K, V > > ::declaration()), ("C"
-            .to_string(), < EnumParametrizedC < T > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("B".to_string(), < EnumParametrizedB < K, V > > ::declaration()), ("C"
+                .to_string(), < EnumParametrizedC < T > > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -36,12 +36,12 @@ where
         struct AC<K: Key>(K, Vec<A>);
         <AB<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <AC<K> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("B".to_string(), < AB < K, V > > ::declaration()), ("C".to_string(), < AC <
-            K > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("B".to_string(), < AB < K, V > > ::declaration()), ("C".to_string(), <
+                AC < K > > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -22,12 +22,12 @@ impl borsh::BorshSchema for A {
         struct AEggs;
         <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -26,12 +26,12 @@ impl reexporter::borsh::BorshSchema for A {
         <AEggs as reexporter::borsh::BorshSchema>::add_definitions_recursively(
             definitions,
         );
-        let variants = reexporter::borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
-            AEggs > ::declaration())
-        ];
         let definition = reexporter::borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: reexporter::borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration()), ("Eggs".to_string(), <
+                AEggs > ::declaration())
+            ],
         };
         reexporter::borsh::schema::add_definition(
             Self::declaration(),

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -17,11 +17,11 @@ impl borsh::BorshSchema for A {
         #[borsh(crate = "borsh")]
         struct ABacon;
         <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Bacon".to_string(), < ABacon > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Bacon".to_string(), < ABacon > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -39,12 +39,12 @@ where
             B: Display + Debug;
         <SideLeft<A> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <SideRight<B> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("Left".to_string(), < SideLeft < A > > ::declaration()), ("Right"
-            .to_string(), < SideRight < B > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("Left".to_string(), < SideLeft < A > > ::declaration()), ("Right"
+                .to_string(), < SideRight < B > > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -40,12 +40,12 @@ where
         );
         <CC3 as borsh::BorshSchema>::add_definitions_recursively(definitions);
         <CC4<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        let variants = borsh::__private::maybestd::vec![
-            ("C3".to_string(), < CC3 > ::declaration()), ("C4".to_string(), < CC4 < K, V
-            > > ::declaration())
-        ];
         let definition = borsh::schema::Definition::Enum {
-            variants,
+            tag_width: 1,
+            variants: borsh::__private::maybestd::vec![
+                ("C3".to_string(), < CC3 > ::declaration()), ("C4".to_string(), < CC4 <
+                K, V > > ::declaration())
+            ],
         };
         borsh::schema::add_definition(Self::declaration(), definition, definitions);
     }

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -64,7 +64,6 @@
 
 */
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// Derive macro available if borsh is built with `features = ["derive", "schema"]`.

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -64,6 +64,7 @@
 
 */
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// Derive macro available if borsh is built with `features = ["derive", "schema"]`.

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -68,7 +68,7 @@ pub enum Definition {
         /// Width in bytes of the discriminant tag.
         ///
         /// Zero indicates this is an untagged union.  In standard borsh
-        /// encoding this is one however custom encoding formats may use larger
+        /// encoding this is one. However custom encoding formats may use larger
         /// width if they need to encode more than 256 variants.
         ///
         /// Note: This definition must not be used if the tag is not encoded

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -238,7 +238,9 @@ fn max_serialized_size_impl<'a>(
 mod tests {
     use super::*;
 
-    use alloc::{
+    // this is not integration test module, so can use __private for ease of imports;
+    // it cannot be made integration, as it tests `is_zero_size` function, chosen to be non-pub
+    use crate::__private::maybestd::{
         boxed::Box,
         collections::BTreeMap,
         string::{String, ToString},

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -111,6 +111,12 @@ fn is_zero_size(declaration: &str, schema: &BorshSchemaContainer) -> bool {
         Ok(Definition::Tuple { elements }) => elements
             .iter()
             .all(|element| is_zero_size(element.as_str(), schema)),
+        Ok(Definition::Enum {
+            tag_width: 0,
+            variants,
+        }) => variants
+            .iter()
+            .all(|variant| is_zero_size(&variant.1, schema)),
         Ok(Definition::Enum { .. }) => false,
         Ok(Definition::Struct { fields }) => match fields {
             Fields::NamedFields(fields) => fields
@@ -187,14 +193,17 @@ fn max_serialized_size_impl<'a>(
             mul(count, add(sz, 4)?)
         }
 
-        Ok(Definition::Enum { variants }) => {
-            // Size of an enum is the largest variant plus one for tag.
+        Ok(Definition::Enum {
+            tag_width,
+            variants,
+        }) => {
             let mut max = 0;
             for (_, variant) in variants {
                 let sz = max_serialized_size_impl(1, variant, schema, stack)?;
                 max = max.max(sz);
             }
-            max.checked_add(1).ok_or(MaxSizeError::Overflow)
+            max.checked_add(usize::from(*tag_width))
+                .ok_or(MaxSizeError::Overflow)
         }
 
         // Tuples and structs sum sizes of all the members.
@@ -225,80 +234,131 @@ fn max_serialized_size_impl<'a>(
     Ok(res)
 }
 
-#[test]
-fn test_max_serialized_size() {
-    #[cfg(not(feature = "std"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
     use alloc::{
         boxed::Box,
+        collections::BTreeMap,
         string::{String, ToString},
+        vec,
     };
 
     #[track_caller]
     fn test_ok<T: BorshSchema>(want: usize) {
-        let schema = borsh::schema::BorshSchemaContainer::for_type::<T>();
+        let schema = BorshSchemaContainer::for_type::<T>();
         assert_eq!(Ok(want), max_serialized_size(&schema));
+        assert_eq!(
+            want == 0,
+            is_zero_size(schema.declaration().as_str(), &schema)
+        );
     }
 
     #[track_caller]
     fn test_err<T: BorshSchema>(err: MaxSizeError) {
-        let schema = borsh::schema::BorshSchemaContainer::for_type::<T>();
+        let schema = BorshSchemaContainer::for_type::<T>();
         assert_eq!(Err(err), max_serialized_size(&schema));
     }
 
     const MAX_LEN: usize = u32::MAX as usize;
 
-    test_ok::<u16>(2);
-    test_ok::<usize>(8);
+    #[test]
+    fn max_serialized_size_built_in_types() {
+        test_ok::<u16>(2);
+        test_ok::<usize>(8);
 
-    test_ok::<Option<()>>(1);
-    test_ok::<Option<u8>>(2);
-    test_ok::<core::result::Result<u8, usize>>(9);
+        test_ok::<Option<()>>(1);
+        test_ok::<Option<u8>>(2);
+        test_ok::<core::result::Result<u8, usize>>(9);
 
-    test_ok::<()>(0);
-    test_ok::<(u8,)>(1);
-    test_ok::<(u8, u32)>(5);
+        test_ok::<()>(0);
+        test_ok::<(u8,)>(1);
+        test_ok::<(u8, u32)>(5);
 
-    test_ok::<[u8; 0]>(0);
-    test_ok::<[u8; 16]>(16);
-    test_ok::<[[u8; 4]; 4]>(16);
+        test_ok::<[u8; 0]>(0);
+        test_ok::<[u8; 16]>(16);
+        test_ok::<[[u8; 4]; 4]>(16);
 
-    test_ok::<Vec<u8>>(4 + MAX_LEN);
-    test_ok::<String>(4 + MAX_LEN);
+        test_ok::<Vec<u8>>(4 + MAX_LEN);
+        test_ok::<String>(4 + MAX_LEN);
 
-    test_err::<Vec<Vec<u8>>>(MaxSizeError::Overflow);
-    test_ok::<Vec<Vec<()>>>(4 + MAX_LEN * 4);
-    test_ok::<[[[(); MAX_LEN]; MAX_LEN]; MAX_LEN]>(0);
-
-    use crate as borsh;
-
-    #[derive(::borsh_derive::BorshSchema)]
-    pub struct Empty;
-
-    #[derive(::borsh_derive::BorshSchema)]
-    pub struct Named {
-        _foo: usize,
-        _bar: [u8; 15],
+        test_err::<Vec<Vec<u8>>>(MaxSizeError::Overflow);
+        test_ok::<Vec<Vec<()>>>(4 + MAX_LEN * 4);
+        test_ok::<[[[(); MAX_LEN]; MAX_LEN]; MAX_LEN]>(0);
     }
 
-    #[derive(::borsh_derive::BorshSchema)]
-    pub struct Unnamed(usize, [u8; 15]);
+    #[test]
+    fn max_serialized_size_derived_types() {
+        use crate as borsh;
 
-    #[derive(::borsh_derive::BorshSchema)]
-    struct Multiple {
-        _usz0: usize,
-        _usz1: usize,
-        _usz2: usize,
-        _vec0: Vec<usize>,
-        _vec1: Vec<usize>,
+        #[derive(::borsh_derive::BorshSchema)]
+        pub struct Empty;
+
+        #[derive(::borsh_derive::BorshSchema)]
+        pub struct Named {
+            _foo: usize,
+            _bar: [u8; 15],
+        }
+
+        #[derive(::borsh_derive::BorshSchema)]
+        pub struct Unnamed(usize, [u8; 15]);
+
+        #[derive(::borsh_derive::BorshSchema)]
+        struct Multiple {
+            _usz0: usize,
+            _usz1: usize,
+            _usz2: usize,
+            _vec0: Vec<usize>,
+            _vec1: Vec<usize>,
+        }
+
+        #[derive(::borsh_derive::BorshSchema)]
+        struct Recursive(Option<Box<Recursive>>);
+
+        test_ok::<Empty>(0);
+        test_ok::<Named>(23);
+        test_ok::<Unnamed>(23);
+        test_ok::<Multiple>(3 * 8 + 2 * (4 + MAX_LEN * 8));
+        test_err::<BorshSchemaContainer>(MaxSizeError::Overflow);
+        test_err::<Recursive>(MaxSizeError::Recursive);
     }
 
-    #[derive(::borsh_derive::BorshSchema)]
-    struct Recursive(Option<Box<Recursive>>);
+    #[test]
+    fn max_serialized_size_custom_enum() {
+        #[allow(dead_code)]
+        enum Maybe<const N: usize, T> {
+            Just(T),
+            Nothing,
+        }
 
-    test_ok::<Empty>(0);
-    test_ok::<Named>(23);
-    test_ok::<Unnamed>(23);
-    test_ok::<Multiple>(3 * 8 + 2 * (4 + MAX_LEN * 8));
-    test_err::<BorshSchemaContainer>(MaxSizeError::Overflow);
-    test_err::<Recursive>(MaxSizeError::Recursive);
+        impl<const N: usize, T: BorshSchema> BorshSchema for Maybe<N, T> {
+            fn declaration() -> Declaration {
+                "Maybe".into()
+            }
+            fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+                let definition = Definition::Enum {
+                    tag_width: N as u8,
+                    variants: vec![
+                        ("Just".into(), T::declaration()),
+                        ("Nothing".into(), "nil".into()),
+                    ],
+                };
+                crate::schema::add_definition(Self::declaration(), definition, definitions);
+                T::add_definitions_recursively(definitions);
+            }
+        }
+
+        test_ok::<Maybe<0, ()>>(0);
+        test_ok::<Maybe<0, u16>>(2);
+        test_ok::<Maybe<0, u64>>(8);
+
+        test_ok::<Maybe<1, ()>>(1);
+        test_ok::<Maybe<1, u16>>(3);
+        test_ok::<Maybe<1, u64>>(9);
+
+        test_ok::<Maybe<4, ()>>(4);
+        test_ok::<Maybe<4, u16>>(6);
+        test_ok::<Maybe<4, u64>>(12);
+    }
 }

--- a/borsh/tests/snapshots/test_schema_enums__complex_enum_with_schema.snap
+++ b/borsh/tests/snapshots/test_schema_enums__complex_enum_with_schema.snap
@@ -18,6 +18,7 @@ expression: data
     0,
     65,
     3,
+    1,
     4,
     0,
     0,

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -46,7 +46,10 @@ pub fn simple_enum() {
         map! {
         "ABacon" => Definition::Struct{ fields: Fields::Empty },
         "AEggs" => Definition::Struct{ fields: Fields::Empty },
-        "A" => Definition::Enum { variants: vec![("Bacon".to_string(), "ABacon".to_string()), ("Eggs".to_string(), "AEggs".to_string())]}
+            "A" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![("Bacon".to_string(), "ABacon".to_string()), ("Eggs".to_string(), "AEggs".to_string())]
+            }
         },
         defs
     );
@@ -63,8 +66,11 @@ pub fn single_field_enum() {
     A::add_definitions_recursively(&mut defs);
     assert_eq!(
         map! {
-        "ABacon" => Definition::Struct {fields: Fields::Empty},
-        "A" => Definition::Enum { variants: vec![("Bacon".to_string(), "ABacon".to_string())]}
+            "ABacon" => Definition::Struct {fields: Fields::Empty},
+            "A" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![("Bacon".to_string(), "ABacon".to_string())]
+            }
         },
         defs
     );
@@ -176,11 +182,15 @@ pub fn complex_enum_with_schema() {
         "ASalad" => Definition::Struct{ fields: Fields::UnnamedFields(vec!["Tomatoes".to_string(), "Cucumber".to_string(), "Oil".to_string()])},
         "ABacon" => Definition::Struct {fields: Fields::Empty},
         "Oil" => Definition::Struct {fields: Fields::Empty},
-        "A" => Definition::Enum{ variants: vec![
-        ("Bacon".to_string(), "ABacon".to_string()),
-        ("Eggs".to_string(), "AEggs".to_string()),
-        ("Salad".to_string(), "ASalad".to_string()),
-        ("Sausage".to_string(), "ASausage".to_string())]},
+            "A" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("Bacon".to_string(), "ABacon".to_string()),
+                    ("Eggs".to_string(), "AEggs".to_string()),
+                    ("Salad".to_string(), "ASalad".to_string()),
+                    ("Sausage".to_string(), "ASausage".to_string())
+                ]
+            },
         "Wrapper" => Definition::Struct {fields: Fields::Empty},
         "Tomatoes" => Definition::Struct {fields: Fields::Empty},
         "ASausage" => Definition::Struct { fields: Fields::NamedFields(vec![
@@ -234,12 +244,13 @@ pub fn complex_enum_generics() {
         },
         "ABacon" => Definition::Struct {fields: Fields::Empty},
         "Oil" => Definition::Struct {fields: Fields::Empty},
-        "A<Cucumber, Wrapper>" => Definition::Enum{
+        "A<Cucumber, Wrapper>" => Definition::Enum {
+            tag_width: 1,
             variants: vec![
-            ("Bacon".to_string(), "ABacon".to_string()),
-            ("Eggs".to_string(), "AEggs".to_string()),
-            ("Salad".to_string(), "ASalad<Cucumber>".to_string()),
-            ("Sausage".to_string(), "ASausage<Wrapper>".to_string())
+                ("Bacon".to_string(), "ABacon".to_string()),
+                ("Eggs".to_string(), "AEggs".to_string()),
+                ("Salad".to_string(), "ASalad<Cucumber>".to_string()),
+                ("Sausage".to_string(), "ASausage<Wrapper>".to_string())
             ]
         },
         "Wrapper" => Definition::Struct {fields: Fields::Empty},
@@ -259,10 +270,13 @@ pub fn complex_enum_generics() {
 
 fn common_map() -> BTreeMap<String, Definition> {
     map! {
-        "EnumParametrized<string, u32, i8, u16>" => Definition::Enum{ variants: vec![
+        "EnumParametrized<string, u32, i8, u16>" => Definition::Enum {
+            tag_width: 1,
+            variants: vec![
                 ("B".to_string(), "EnumParametrizedB<u32, i8, u16>".to_string()),
                 ("C".to_string(), "EnumParametrizedC<string>".to_string())
-            ]},
+            ]
+        },
         "EnumParametrizedB<u32, i8, u16>" => Definition::Struct { fields: Fields::NamedFields(vec![
             ("x".to_string(), "BTreeMap<u32, u16>".to_string()),
             ("y".to_string(), "string".to_string()),

--- a/borsh/tests/test_schema_nested.rs
+++ b/borsh/tests/test_schema_nested.rs
@@ -68,17 +68,24 @@ pub fn duplicated_instantiations() {
     <A<Cucumber, Wrapper<String>>>::add_definitions_recursively(&mut defs);
     assert_eq!(
         map! {
-        "A<Cucumber, Wrapper<string>>" => Definition::Enum {variants: vec![
-         ("Bacon".to_string(), "ABacon".to_string()),
-         ("Eggs".to_string(), "AEggs".to_string()),
-         ("Salad".to_string(), "ASalad<Cucumber>".to_string()),
-         ("Sausage".to_string(), "ASausage<Wrapper<string>>".to_string())
-        ]},
-        "A<string, string>" => Definition::Enum {variants: vec![
-            ("Bacon".to_string(), "ABacon".to_string()),
-            ("Eggs".to_string(), "AEggs".to_string()),
-            ("Salad".to_string(), "ASalad<string>".to_string()),
-            ("Sausage".to_string(), "ASausage<string>".to_string())]},
+            "A<Cucumber, Wrapper<string>>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("Bacon".to_string(), "ABacon".to_string()),
+                    ("Eggs".to_string(), "AEggs".to_string()),
+                    ("Salad".to_string(), "ASalad<Cucumber>".to_string()),
+                    ("Sausage".to_string(), "ASausage<Wrapper<string>>".to_string())
+                ]
+            },
+            "A<string, string>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("Bacon".to_string(), "ABacon".to_string()),
+                    ("Eggs".to_string(), "AEggs".to_string()),
+                    ("Salad".to_string(), "ASalad<string>".to_string()),
+                    ("Sausage".to_string(), "ASausage<string>".to_string())
+                ]
+            },
         "ABacon" => Definition::Struct {fields: Fields::Empty},
         "AEggs" => Definition::Struct {fields: Fields::Empty},
         "ASalad<Cucumber>" => Definition::Struct {fields: Fields::UnnamedFields(vec!["Tomatoes".to_string(), "Cucumber".to_string(), "Oil<u64, string>".to_string()])},
@@ -89,8 +96,20 @@ pub fn duplicated_instantiations() {
         "Filling" => Definition::Struct {fields: Fields::Empty},
         "HashMap<u64, string>" => Definition::Sequence { elements: "Tuple<u64, string>".to_string()},
         "Oil<u64, string>" => Definition::Struct { fields: Fields::NamedFields(vec![("seeds".to_string(), "HashMap<u64, string>".to_string()), ("liquid".to_string(), "Option<u64>".to_string())])},
-        "Option<string>" => Definition::Enum {variants: vec![("None".to_string(), "nil".to_string()), ("Some".to_string(), "string".to_string())]},
-        "Option<u64>" => Definition::Enum { variants: vec![("None".to_string(), "nil".to_string()), ("Some".to_string(), "u64".to_string())]},
+            "Option<string>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("None".to_string(), "nil".to_string()),
+                    ("Some".to_string(), "string".to_string())
+                ]
+            },
+            "Option<u64>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("None".to_string(), "nil".to_string()),
+                    ("Some".to_string(), "u64".to_string())
+                ]
+            },
         "Tomatoes" => Definition::Struct {fields: Fields::Empty},
         "Tuple<u64, string>" => Definition::Tuple {elements: vec!["u64".to_string(), "string".to_string()]},
         "Wrapper<string>" => Definition::Struct{ fields: Fields::NamedFields(vec![("foo".to_string(), "Option<string>".to_string()), ("bar".to_string(), "A<string, string>".to_string())])}

--- a/borsh/tests/test_schema_recursive.rs
+++ b/borsh/tests/test_schema_recursive.rs
@@ -76,39 +76,24 @@ pub fn recursive_enum_schema() {
     assert_eq!(
         map! {
            "ERecD" => Definition::Enum {
+                tag_width: 1,
                 variants: vec![
-
-                    (
-                        "B".to_string(),
-                        "ERecDB".to_string(),
-                    ),
-                    (
-                        "C".to_string(),
-                        "ERecDC".to_string(),
-                    ),
+                    ("B".to_string(), "ERecDB".to_string()),
+                    ("C".to_string(), "ERecDC".to_string()),
                 ]
             },
             "ERecDB" => Definition::Struct {
-
                 fields: Fields::NamedFields (
                     vec![
-                        (
-                            "x".to_string(),
-                            "string".to_string(),
-                        ),
-                        (
-                            "y".to_string(),
-                            "i32".to_string(),
-                        ),
+                        ("x".to_string(), "string".to_string()),
+                        ("y".to_string(), "i32".to_string()),
                     ]
-
                 )
             },
             "ERecDC" => Definition::Struct {
                 fields: Fields::UnnamedFields( vec![
                     "u8".to_string(),
                     "Vec<ERecD>".to_string(),
-
                 ])
             },
             "Vec<ERecD>" => Definition::Sequence {

--- a/borsh/tests/test_schema_with.rs
+++ b/borsh/tests/test_schema_with.rs
@@ -130,10 +130,13 @@ pub fn enum_overriden() {
     <C<u64, String>>::add_definitions_recursively(&mut defs);
     assert_eq!(
         map! {
-            "C<u64, string>" => Definition::Enum { variants: vec![
-                ("C3".to_string(), "CC3".to_string()),
-                ("C4".to_string(), "CC4<u64, string>".to_string())
-            ] },
+            "C<u64, string>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    ("C3".to_string(), "CC3".to_string()),
+                    ("C4".to_string(), "CC4<u64, string>".to_string())
+                ]
+            },
             "CC3" => Definition::Struct { fields: Fields::UnnamedFields(vec!["u64".to_string(), "u64".to_string()]) },
             "CC4<u64, string>" => Definition::Struct { fields: Fields::UnnamedFields(vec![
                 "u64".to_string(), "ThirdParty<u64, string>".to_string()

--- a/borsh/tests/test_zero_sized_types.rs
+++ b/borsh/tests/test_zero_sized_types.rs
@@ -38,6 +38,20 @@ fn test_serialize_vec_of_zst() {
 }
 
 #[test]
+fn test_serialize_vec_of_unit_type() {
+    let v = vec![(), (), ()];
+    let res = to_vec(&v);
+    assert_eq!(res.unwrap_err().to_string(), ERROR_ZST_FORBIDDEN);
+}
+
+#[test]
+fn test_serialize_vec_of_vec_of_unit_type() {
+    let v: Vec<Vec<()>> = vec![vec![(), (), ()]];
+    let res = to_vec(&v);
+    assert_eq!(res.unwrap_err().to_string(), ERROR_ZST_FORBIDDEN);
+}
+
+#[test]
 fn test_deserialize_vec_deque_of_zst() {
     let v = [0u8, 0u8, 0u8, 64u8];
     let res = from_slice::<VecDeque<A>>(&v);


### PR DESCRIPTION
The field allows specifying how many bytes the discriminant byte
takes. This in turn allows for better support of custom encoding
formats with more than 256 variants and untagged unions.

```rust
    Enum {
        /// Width in bytes of the discriminant tag.
        ///
        /// Zero indicates this is an untagged union.  In standard borsh
        /// encoding this is one however custom encoding formats may use larger
        /// width if they need to encode more than 256 variants.
        ///
        /// Note: This definition must not be used if the tag is not encoded
        /// using little-endian format.
        tag_width: u8,

        /// Possible variants of the enumeration.
        variants: Vec<(VariantName, Declaration)>,
    },
```

relates to: https://github.com/near/borsh-rs/issues/181
