### PR TITLE
feat!: add `Definition::Sequence::length_range` field

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -110,8 +110,7 @@ impl Definition {
     /// Convenience constant representing the length range of a standard borsh
     /// sequence.
     ///
-    /// It equals `0..=u32::MAX`.  Can be used for `Definition::Array::length`
-    /// and `Definition::Sequence::length`.
+    /// It equals `0..=u32::MAX`.  Can be used for `Definition::Sequence::length`.
     pub const DEFAULT_LENGTH_RANGE: core::ops::RangeInclusive<u32> = 0..=u32::MAX;
 }
 

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -283,7 +283,10 @@ fn common_map() -> BTreeMap<String, Definition> {
             ("z".to_string(), "i8".to_string())
         ])},
         "EnumParametrizedC<string>" => Definition::Struct{ fields: Fields::UnnamedFields(vec!["string".to_string(), "u16".to_string()])},
-        "BTreeMap<u32, u16>" => Definition::Sequence { elements: "Tuple<u32, u16>".to_string()},
+        "BTreeMap<u32, u16>" => Definition::Sequence {
+            length_range: Definition::DEFAULT_LENGTH_RANGE,
+            elements: "Tuple<u32, u16>".to_string(),
+        },
         "Tuple<u32, u16>" => Definition::Tuple { elements: vec!["u32".to_string(), "u16".to_string()]},
         "u32" => Definition::Primitive(4),
         "i8" => Definition::Primitive(1),

--- a/borsh/tests/test_schema_nested.rs
+++ b/borsh/tests/test_schema_nested.rs
@@ -94,7 +94,10 @@ pub fn duplicated_instantiations() {
         "ASausage<string>" => Definition::Struct{ fields: Fields::NamedFields(vec![("wrapper".to_string(), "string".to_string()), ("filling".to_string(), "Filling".to_string())])},
         "Cucumber" => Definition::Struct {fields: Fields::Empty},
         "Filling" => Definition::Struct {fields: Fields::Empty},
-        "HashMap<u64, string>" => Definition::Sequence { elements: "Tuple<u64, string>".to_string()},
+            "HashMap<u64, string>" => Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
+                elements: "Tuple<u64, string>".to_string(),
+            },
         "Oil<u64, string>" => Definition::Struct { fields: Fields::NamedFields(vec![("seeds".to_string(), "HashMap<u64, string>".to_string()), ("liquid".to_string(), "Option<u64>".to_string())])},
             "Option<string>" => Definition::Enum {
                 tag_width: 1,

--- a/borsh/tests/test_schema_recursive.rs
+++ b/borsh/tests/test_schema_recursive.rs
@@ -60,8 +60,8 @@ pub fn recursive_struct_schema() {
 
             },
             "BTreeMap<string, CRecC>" => Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
                 elements: "Tuple<string, CRecC>".to_string(),
-
             },
             "Tuple<string, CRecC>" => Definition::Tuple {elements: vec!["string".to_string(), "CRecC".to_string()]}
         },
@@ -97,8 +97,8 @@ pub fn recursive_enum_schema() {
                 ])
             },
             "Vec<ERecD>" => Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
                 elements: "ERecD".to_string(),
-
             },
             "i32" => Definition::Primitive(4),
             "u8" => Definition::Primitive(1)

--- a/borsh/tests/test_schema_structs.rs
+++ b/borsh/tests/test_schema_structs.rs
@@ -84,7 +84,10 @@ pub fn boxed() {
     A::add_definitions_recursively(&mut defs);
     assert_eq!(
         map! {
-        "Vec<u8>" => Definition::Sequence { elements: "u8".to_string() },
+            "Vec<u8>" => Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
+                elements: "u8".to_string(),
+            },
         "A" => Definition::Struct{ fields: Fields::NamedFields(vec![
         ("_f1".to_string(), "u64".to_string()),
         ("_f2".to_string(), "string".to_string()),
@@ -174,7 +177,10 @@ pub fn simple_generics() {
         ("_f2".to_string(), "string".to_string())
         ])
         },
-        "HashMap<u64, string>" => Definition::Sequence {elements: "Tuple<u64, string>".to_string()},
+            "HashMap<u64, string>" => Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
+                elements: "Tuple<u64, string>".to_string(),
+            },
         "Tuple<u64, string>" => Definition::Tuple{elements: vec!["u64".to_string(), "string".to_string()]},
         "u64" => Definition::Primitive(8)
         },

--- a/borsh/tests/test_schema_with.rs
+++ b/borsh/tests/test_schema_with.rs
@@ -113,7 +113,10 @@ pub fn struct_overriden() {
             "ThirdParty<u64, string>" => Definition::Struct { fields: Fields::UnnamedFields(vec![
                 "BTreeMap<u64, string>".to_string(),
             ]) },
-            "BTreeMap<u64, string>"=> Definition::Sequence { elements: "Tuple<u64, string>".to_string() },
+            "BTreeMap<u64, string>"=> Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
+                elements: "Tuple<u64, string>".to_string(),
+            },
             "Tuple<u64, string>" => Definition::Tuple { elements: vec!["u64".to_string(), "string".to_string()]},
             "u64" => Definition::Primitive(8)
         },
@@ -145,7 +148,10 @@ pub fn enum_overriden() {
             "ThirdParty<u64, string>" => Definition::Struct { fields: Fields::UnnamedFields(vec![
                 "BTreeMap<u64, string>".to_string(),
             ]) },
-            "BTreeMap<u64, string>"=> Definition::Sequence { elements: "Tuple<u64, string>".to_string() },
+            "BTreeMap<u64, string>"=> Definition::Sequence {
+                length_range: Definition::DEFAULT_LENGTH_RANGE,
+                elements: "Tuple<u64, string>".to_string(),
+            },
             "Tuple<u64, string>" => Definition::Tuple { elements: vec!["u64".to_string(), "string".to_string()]},
             "u64" => Definition::Primitive(8)
         },


### PR DESCRIPTION
Having a length_range field in the Sequence definition allows to
better specify encoding formats for bounded vectors.  This in turn
helps with performing calculations such as figuring out the maximum or
minimum length of encoding of a type.
