### PR TITLE
chore!: rename `"Tuple<T0, T1, T2...>"` -> `"(T0, T1, T2...)"` (`schema::Declaration`)

### DIFF
--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -667,7 +667,11 @@ macro_rules! impl_tuple {
 
         fn declaration() -> Declaration {
             let params = vec![$($name::declaration()),+];
-            format!(r#"Tuple<{}>"#, params.join(", "))
+            if params.len() == 1 {
+                format!(r#"({},)"#, params[0])
+            } else {
+                format!(r#"({})"#, params.join(", "))
+            }
         }
     }
     };
@@ -817,10 +821,10 @@ mod tests {
         let actual_name = <(u64, core::num::NonZeroU16, String)>::declaration();
         let mut actual_defs = map!();
         <(u64, core::num::NonZeroU16, String)>::add_definitions_recursively(&mut actual_defs);
-        assert_eq!("Tuple<u64, NonZeroU16, String>", actual_name);
+        assert_eq!("(u64, NonZeroU16, String)", actual_name);
         assert_eq!(
             map! {
-                "Tuple<u64, NonZeroU16, String>" => Definition::Tuple {
+                "(u64, NonZeroU16, String)" => Definition::Tuple {
                     elements: vec![
                         "u64".to_string(),
                         "NonZeroU16".to_string(),
@@ -845,15 +849,15 @@ mod tests {
         let actual_name = <(u64, (u8, bool), String)>::declaration();
         let mut actual_defs = map!();
         <(u64, (u8, bool), String)>::add_definitions_recursively(&mut actual_defs);
-        assert_eq!("Tuple<u64, Tuple<u8, bool>, String>", actual_name);
+        assert_eq!("(u64, (u8, bool), String)", actual_name);
         assert_eq!(
             map! {
-                "Tuple<u64, Tuple<u8, bool>, String>" => Definition::Tuple { elements: vec![
+                "(u64, (u8, bool), String)" => Definition::Tuple { elements: vec![
                     "u64".to_string(),
-                    "Tuple<u8, bool>".to_string(),
+                    "(u8, bool)".to_string(),
                     "String".to_string(),
                 ]},
-                "Tuple<u8, bool>" => Definition::Tuple { elements: vec![ "u8".to_string(), "bool".to_string()]},
+                "(u8, bool)" => Definition::Tuple { elements: vec![ "u8".to_string(), "bool".to_string()]},
                 "u64" => Definition::Primitive(8),
                 "u8" => Definition::Primitive(1),
                 "bool" => Definition::Primitive(1),
@@ -879,9 +883,9 @@ mod tests {
                 "HashMap<u64, String>" => Definition::Sequence {
                     length_width: Definition::DEFAULT_LENGTH_WIDTH,
                     length_range: Definition::DEFAULT_LENGTH_RANGE,
-                    elements: "Tuple<u64, String>".to_string(),
+                    elements: "(u64, String)".to_string(),
                 } ,
-                "Tuple<u64, String>" => Definition::Tuple {
+                "(u64, String)" => Definition::Tuple {
                     elements: vec![ "u64".to_string(), "String".to_string()],
                 },
                 "u64" => Definition::Primitive(8),
@@ -933,9 +937,9 @@ mod tests {
                 "BTreeMap<u64, String>" => Definition::Sequence {
                     length_width: Definition::DEFAULT_LENGTH_WIDTH,
                     length_range: Definition::DEFAULT_LENGTH_RANGE,
-                    elements: "Tuple<u64, String>".to_string(),
+                    elements: "(u64, String)".to_string(),
                 } ,
-                "Tuple<u64, String>" => Definition::Tuple { elements: vec![ "u64".to_string(), "String".to_string()]},
+                "(u64, String)" => Definition::Tuple { elements: vec![ "u64".to_string(), "String".to_string()]},
                 "u64" => Definition::Primitive(8),
                 "String" => Definition::Sequence {
                     length_width: Definition::DEFAULT_LENGTH_WIDTH,

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -286,9 +286,9 @@ fn common_map() -> BTreeMap<String, Definition> {
         "BTreeMap<u32, u16>" => Definition::Sequence {
             length_width: Definition::DEFAULT_LENGTH_WIDTH,
             length_range: Definition::DEFAULT_LENGTH_RANGE,
-            elements: "Tuple<u32, u16>".to_string(),
+            elements: "(u32, u16)".to_string(),
         },
-        "Tuple<u32, u16>" => Definition::Tuple { elements: vec!["u32".to_string(), "u16".to_string()]},
+        "(u32, u16)" => Definition::Tuple { elements: vec!["u32".to_string(), "u16".to_string()]},
         "u32" => Definition::Primitive(4),
         "i8" => Definition::Primitive(1),
         "u16" => Definition::Primitive(2),

--- a/borsh/tests/test_schema_nested.rs
+++ b/borsh/tests/test_schema_nested.rs
@@ -97,7 +97,7 @@ pub fn duplicated_instantiations() {
             "HashMap<u64, String>" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,
-                elements: "Tuple<u64, String>".to_string(),
+                elements: "(u64, String)".to_string(),
             },
         "Oil<u64, String>" => Definition::Struct { fields: Fields::NamedFields(vec![("seeds".to_string(), "HashMap<u64, String>".to_string()), ("liquid".to_string(), "Option<u64>".to_string())])},
             "Option<String>" => Definition::Enum {
@@ -115,7 +115,7 @@ pub fn duplicated_instantiations() {
                 ]
             },
         "Tomatoes" => Definition::Struct {fields: Fields::Empty},
-        "Tuple<u64, String>" => Definition::Tuple {elements: vec!["u64".to_string(), "String".to_string()]},
+        "(u64, String)" => Definition::Tuple {elements: vec!["u64".to_string(), "String".to_string()]},
         "Wrapper<String>" => Definition::Struct{ fields: Fields::NamedFields(vec![("foo".to_string(), "Option<String>".to_string()), ("bar".to_string(), "A<String, String>".to_string())])},
         "u64" => Definition::Primitive(8),
         "()" => Definition::Primitive(0),

--- a/borsh/tests/test_schema_recursive.rs
+++ b/borsh/tests/test_schema_recursive.rs
@@ -62,9 +62,9 @@ pub fn recursive_struct_schema() {
             "BTreeMap<String, CRecC>" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,
-                elements: "Tuple<String, CRecC>".to_string(),
+                elements: "(String, CRecC)".to_string(),
             },
-            "Tuple<String, CRecC>" => Definition::Tuple {elements: vec!["String".to_string(), "CRecC".to_string()]},
+            "(String, CRecC)" => Definition::Tuple {elements: vec!["String".to_string(), "CRecC".to_string()]},
             "String" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,

--- a/borsh/tests/test_schema_structs.rs
+++ b/borsh/tests/test_schema_structs.rs
@@ -204,9 +204,9 @@ pub fn simple_generics() {
             "HashMap<u64, String>" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,
-                elements: "Tuple<u64, String>".to_string(),
+                elements: "(u64, String)".to_string(),
             },
-        "Tuple<u64, String>" => Definition::Tuple{elements: vec!["u64".to_string(), "String".to_string()]},
+        "(u64, String)" => Definition::Tuple{elements: vec!["u64".to_string(), "String".to_string()]},
         "u64" => Definition::Primitive(8),
         "String" => Definition::Sequence {
             length_width: Definition::DEFAULT_LENGTH_WIDTH,
@@ -337,11 +337,11 @@ pub fn generic_associated_item3() {
         map! {
             "Parametrized<String, u32, i8>" => Definition::Struct {
                 fields: Fields::NamedFields(vec![
-                    ("field".to_string(), "Tuple<i8, u32>".to_string()),
+                    ("field".to_string(), "(i8, u32)".to_string()),
                     ("another".to_string(), "String".to_string())
                 ])
             },
-            "Tuple<i8, u32>" => Definition::Tuple {
+            "(i8, u32)" => Definition::Tuple {
                 elements: vec!["i8".to_string(), "u32".to_string()]
             },
             "i8" => Definition::Primitive(1),

--- a/borsh/tests/test_schema_tuple.rs
+++ b/borsh/tests/test_schema_tuple.rs
@@ -26,12 +26,12 @@ macro_rules! map(
 
 #[test]
 fn test_unary_tuple_schema() {
-    assert_eq!("Tuple<bool>", <(bool,)>::declaration());
+    assert_eq!("(bool,)", <(bool,)>::declaration());
     let mut defs = Default::default();
     <(bool,)>::add_definitions_recursively(&mut defs);
     assert_eq!(
         map! {
-        "Tuple<bool>" => Definition::Tuple { elements: vec!["bool".to_string()] },
+        "(bool,)" => Definition::Tuple { elements: vec!["bool".to_string()] },
         "bool" => Definition::Primitive(1)
         },
         defs

--- a/borsh/tests/test_schema_with.rs
+++ b/borsh/tests/test_schema_with.rs
@@ -116,9 +116,9 @@ pub fn struct_overriden() {
             "BTreeMap<u64, String>"=> Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,
-                elements: "Tuple<u64, String>".to_string(),
+                elements: "(u64, String)".to_string(),
             },
-            "Tuple<u64, String>" => Definition::Tuple { elements: vec!["u64".to_string(), "String".to_string()]},
+            "(u64, String)" => Definition::Tuple { elements: vec!["u64".to_string(), "String".to_string()]},
             "u64" => Definition::Primitive(8),
             "String" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
@@ -158,9 +158,9 @@ pub fn enum_overriden() {
             "BTreeMap<u64, String>"=> Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,
                 length_range: Definition::DEFAULT_LENGTH_RANGE,
-                elements: "Tuple<u64, String>".to_string(),
+                elements: "(u64, String)".to_string(),
             },
-            "Tuple<u64, String>" => Definition::Tuple { elements: vec!["u64".to_string(), "String".to_string()]},
+            "(u64, String)" => Definition::Tuple { elements: vec!["u64".to_string(), "String".to_string()]},
             "u64" => Definition::Primitive(8),
             "String" => Definition::Sequence {
                 length_width: Definition::DEFAULT_LENGTH_WIDTH,


### PR DESCRIPTION
part of #231 resolution