### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.6](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.5...borsh-v1.0.0-alpha.6) - 2023-10-02
+
+### Added
+- add `borsh::object_length` helper ([#236](https://github.com/near/borsh-rs/pull/236))
+
+### Other
+- add examples for `borsh::to_vec`, `borsh::to_writer`, `borsh::object_length` ([#238](https://github.com/near/borsh-rs/pull/238))
+- [**breaking**] completely remove deprecated `BorshSerialize::try_to_vec` ([#221](https://github.com/near/borsh-rs/pull/221))
+
 ## [1.0.0-alpha.5](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.4...borsh-v1.0.0-alpha.5) - 2023-09-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["std", "unstable__schema"]
 cfg_aliases = "0.1.0"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.5", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "1.0.0-alpha.6", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get 


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `borsh-derive`: 1.0.0-alpha.5 -> 1.0.0-alpha.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.0.0-alpha.6](https://github.com/near/borsh-rs/compare/borsh-v1.0.0-alpha.5...borsh-v1.0.0-alpha.6) - 2023-10-02

### Added
- add `borsh::object_length` helper ([#236](https://github.com/near/borsh-rs/pull/236))

### Other
- add examples for `borsh::to_vec`, `borsh::to_writer`, `borsh::object_length` ([#238](https://github.com/near/borsh-rs/pull/238))
- [**breaking**] completely remove deprecated `BorshSerialize::try_to_vec` ([#221](https://github.com/near/borsh-rs/pull/221))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).