### PR TITLE
[experiment] chore: add `<T as BorshSerialize>::ALLOCATION_HINT` field

### DIFF
--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -2,8 +2,6 @@ use crate::BorshSerialize;
 use crate::__private::maybestd::vec::Vec;
 use crate::io::{ErrorKind, Result, Write};
 
-pub(super) const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
-
 /// Serialize an object into a vector of bytes.
 /// # Example
 ///
@@ -14,7 +12,8 @@ pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
     T: BorshSerialize + ?Sized,
 {
-    let mut result = Vec::with_capacity(DEFAULT_SERIALIZER_CAPACITY);
+    let mut result = Vec::with_capacity(<T as BorshSerialize>::ALLOCATION_HINT);
+    dbg!(<T as BorshSerialize>::ALLOCATION_HINT);
     value.serialize(&mut result)?;
     Ok(result)
 }

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -52,6 +52,8 @@ const FLOAT_NAN_ERR: &str = "For portability reasons we do not allow to serializ
 /// x.serialize(&mut buffer_slice_enough_for_the_data).unwrap();
 /// ```
 pub trait BorshSerialize {
+    const ALLOCATION_HINT: usize = 1024;
+
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()>;
 
     #[inline]
@@ -66,6 +68,8 @@ pub trait BorshSerialize {
 }
 
 impl BorshSerialize for u8 {
+    const ALLOCATION_HINT: usize = 1;
+
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
         writer.write_all(core::slice::from_ref(self))
@@ -78,8 +82,11 @@ impl BorshSerialize for u8 {
 }
 
 macro_rules! impl_for_integer {
-    ($type: ident) => {
+    ($type: ident, $size: expr) => {
         impl BorshSerialize for $type {
+
+            const ALLOCATION_HINT: usize = $size;
+
             #[inline]
             fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
                 let bytes = self.to_le_bytes();
@@ -89,15 +96,15 @@ macro_rules! impl_for_integer {
     };
 }
 
-impl_for_integer!(i8);
-impl_for_integer!(i16);
-impl_for_integer!(i32);
-impl_for_integer!(i64);
-impl_for_integer!(i128);
-impl_for_integer!(u16);
-impl_for_integer!(u32);
-impl_for_integer!(u64);
-impl_for_integer!(u128);
+impl_for_integer!(i8, 1);
+impl_for_integer!(i16, 2);
+impl_for_integer!(i32, 4);
+impl_for_integer!(i64, 8);
+impl_for_integer!(i128, 16);
+impl_for_integer!(u16, 2);
+impl_for_integer!(u32, 4);
+impl_for_integer!(u64, 8);
+impl_for_integer!(u128, 16);
 
 macro_rules! impl_for_nonzero_integer {
     ($type: ty) => {

--- a/borsh/tests/smoke.rs
+++ b/borsh/tests/smoke.rs
@@ -18,6 +18,9 @@ fn test_to_vec() {
 
     let seriazeble = (schema_container_of::<u8>(), value);
     let serialized = borsh::to_vec(&seriazeble).unwrap();
+
+    let _other = borsh::to_vec(&value).unwrap();
+    let _other = borsh::to_vec(&16u16).unwrap();
     #[cfg(feature = "std")]
     println!("serialized: {:?}", serialized);
     let deserialized = try_from_slice_with_schema::<u8>(&serialized).unwrap();


### PR DESCRIPTION
pr is not for merge, just to illustrate a microoptimization
> may make sense to override initial vector allocation capacity per type, but that can be done with introducing a constant on BorshSerialize trait

from [comment](https://github.com/near/nearcore/pull/9432#issuecomment-1755255936)