### PR TITLE
chore: fully qualify `#cratename::BorshSchema` in derive

### DIFF
--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -178,7 +178,7 @@ impl Attributes {
     }
     pub(crate) fn collect_bounds(&self, ty: BoundType) -> Vec<WherePredicate> {
         let predicates = self.get_bounds(ty);
-        predicates.unwrap_or(vec![])
+        predicates.unwrap_or_default()
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -72,7 +72,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
                 tag_width: 1,
                 variants: #cratename::__private::maybestd::vec![#(#variants_defs),*],
             };
-            #cratename::schema::add_definition(Self::declaration(), definition, definitions);
+            #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions);
         }
     };
 
@@ -147,7 +147,7 @@ fn process_variant(
         process_discriminant(&variant.ident, discriminant_info)?;
 
     let variant_entry = quote! {
-        (#discriminant_variable as i64, #variant_name.to_string(), <#full_variant_ident #inner_struct_ty_generics>::declaration())
+        (#discriminant_variable as i64, #variant_name.to_string(), <#full_variant_ident #inner_struct_ty_generics as #cratename::BorshSchema>::declaration())
     };
     Ok(VariantOutput {
         inner_struct,

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
@@ -51,15 +51,21 @@ impl borsh::BorshSchema for X {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "A".to_string(), < XA > ::declaration()),
-                (discriminant_1 as i64, "B".to_string(), < XB > ::declaration()),
-                (discriminant_2 as i64, "C".to_string(), < XC > ::declaration()),
-                (discriminant_3 as i64, "D".to_string(), < XD > ::declaration()),
-                (discriminant_4 as i64, "E".to_string(), < XE > ::declaration()),
-                (discriminant_5 as i64, "F".to_string(), < XF > ::declaration())
+                (discriminant_0 as i64, "A".to_string(), < XA as borsh::BorshSchema >
+                ::declaration()), (discriminant_1 as i64, "B".to_string(), < XB as
+                borsh::BorshSchema > ::declaration()), (discriminant_2 as i64, "C"
+                .to_string(), < XC as borsh::BorshSchema > ::declaration()),
+                (discriminant_3 as i64, "D".to_string(), < XD as borsh::BorshSchema >
+                ::declaration()), (discriminant_4 as i64, "E".to_string(), < XE as
+                borsh::BorshSchema > ::declaration()), (discriminant_5 as i64, "F"
+                .to_string(), < XF as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
@@ -51,15 +51,21 @@ impl borsh::BorshSchema for X {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "A".to_string(), < XA > ::declaration()),
-                (discriminant_1 as i64, "B".to_string(), < XB > ::declaration()),
-                (discriminant_2 as i64, "C".to_string(), < XC > ::declaration()),
-                (discriminant_3 as i64, "D".to_string(), < XD > ::declaration()),
-                (discriminant_4 as i64, "E".to_string(), < XE > ::declaration()),
-                (discriminant_5 as i64, "F".to_string(), < XF > ::declaration())
+                (discriminant_0 as i64, "A".to_string(), < XA as borsh::BorshSchema >
+                ::declaration()), (discriminant_1 as i64, "B".to_string(), < XB as
+                borsh::BorshSchema > ::declaration()), (discriminant_2 as i64, "C"
+                .to_string(), < XC as borsh::BorshSchema > ::declaration()),
+                (discriminant_3 as i64, "D".to_string(), < XD as borsh::BorshSchema >
+                ::declaration()), (discriminant_4 as i64, "E".to_string(), < XE as
+                borsh::BorshSchema > ::declaration()), (discriminant_5 as i64, "F"
+                .to_string(), < XF as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -42,14 +42,19 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration()),
-                (discriminant_2 as i64, "Salad".to_string(), < ASalad > ::declaration()),
-                (discriminant_3 as i64, "Sausage".to_string(), < ASausage >
-                ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Eggs"
+                .to_string(), < AEggs as borsh::BorshSchema > ::declaration()),
+                (discriminant_2 as i64, "Salad".to_string(), < ASalad as
+                borsh::BorshSchema > ::declaration()), (discriminant_3 as i64, "Sausage"
+                .to_string(), < ASausage as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < C > ::declaration(), < W > ::declaration()
+            < C as borsh::BorshSchema > ::declaration(), < W as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -49,14 +50,19 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration()),
-                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > >
-                ::declaration()), (discriminant_3 as i64, "Sausage".to_string(), <
-                ASausage < W > > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Eggs"
+                .to_string(), < AEggs as borsh::BorshSchema > ::declaration()),
+                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > as
+                borsh::BorshSchema > ::declaration()), (discriminant_3 as i64, "Sausage"
+                .to_string(), < ASausage < W > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < U > ::declaration(), < C > ::declaration()
+            < U as borsh::BorshSchema > ::declaration(), < C as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -51,14 +52,20 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration()),
-                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > >
-                ::declaration()), (discriminant_3 as i64, "Sausage".to_string(), <
-                ASausage < W, U > > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Eggs"
+                .to_string(), < AEggs as borsh::BorshSchema > ::declaration()),
+                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > as
+                borsh::BorshSchema > ::declaration()), (discriminant_3 as i64, "Sausage"
+                .to_string(), < ASausage < W, U > as borsh::BorshSchema >
+                ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -8,7 +8,9 @@ where
     W: borsh::BorshSchema,
 {
     fn declaration() -> borsh::schema::Declaration {
-        let params = borsh::__private::maybestd::vec![< W > ::declaration()];
+        let params = borsh::__private::maybestd::vec![
+            < W as borsh::BorshSchema > ::declaration()
+        ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
     fn add_definitions_recursively(
@@ -50,14 +52,19 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration()),
-                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > >
-                ::declaration()), (discriminant_3 as i64, "Sausage".to_string(), <
-                ASausage < W > > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Eggs"
+                .to_string(), < AEggs as borsh::BorshSchema > ::declaration()),
+                (discriminant_2 as i64, "Salad".to_string(), < ASalad < C > as
+                borsh::BorshSchema > ::declaration()), (discriminant_3 as i64, "Sausage"
+                .to_string(), < ASausage < W > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -34,12 +34,16 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "B".to_string(), < AB > ::declaration()),
-                (discriminant_1 as i64, "Negative".to_string(), < ANegative >
-                ::declaration())
+                (discriminant_0 as i64, "B".to_string(), < AB as borsh::BorshSchema >
+                ::declaration()), (discriminant_1 as i64, "Negative".to_string(), <
+                ANegative as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -15,8 +15,9 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < T > ::declaration(), < K > ::declaration(), < K::Associated >
-            ::declaration(), < V > ::declaration()
+            < T as borsh::BorshSchema > ::declaration(), < K as borsh::BorshSchema >
+            ::declaration(), < K::Associated as borsh::BorshSchema > ::declaration(), < V
+            as borsh::BorshSchema > ::declaration()
         ];
         format!(r#"{}<{}>"#, "EnumParametrized", params.join(", "))
     }
@@ -60,12 +61,17 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "B".to_string(), < EnumParametrizedB < K, V > >
-                ::declaration()), (discriminant_1 as i64, "C".to_string(), <
-                EnumParametrizedC < T > > ::declaration())
+                (discriminant_0 as i64, "B".to_string(), < EnumParametrizedB < K, V > as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "C"
+                .to_string(), < EnumParametrizedC < T > as borsh::BorshSchema >
+                ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -15,8 +15,9 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < T > ::declaration(), < K > ::declaration(), < < K as TraitName >
-            ::Associated > ::declaration(), < V > ::declaration()
+            < T as borsh::BorshSchema > ::declaration(), < K as borsh::BorshSchema >
+            ::declaration(), < < K as TraitName > ::Associated as borsh::BorshSchema >
+            ::declaration(), < V as borsh::BorshSchema > ::declaration()
         ];
         format!(r#"{}<{}>"#, "EnumParametrized", params.join(", "))
     }
@@ -61,12 +62,17 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "B".to_string(), < EnumParametrizedB < K, V > >
-                ::declaration()), (discriminant_1 as i64, "C".to_string(), <
-                EnumParametrizedC < T > > ::declaration())
+                (discriminant_0 as i64, "B".to_string(), < EnumParametrizedB < K, V > as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "C"
+                .to_string(), < EnumParametrizedC < T > as borsh::BorshSchema >
+                ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -10,7 +10,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -41,12 +42,16 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "B".to_string(), < AB < K, V > >
-                ::declaration()), (discriminant_1 as i64, "C".to_string(), < AC < K > >
-                ::declaration())
+                (discriminant_0 as i64, "B".to_string(), < AB < K, V > as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "C"
+                .to_string(), < AC < K > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -27,11 +27,16 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Eggs"
+                .to_string(), < AEggs as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -31,12 +31,14 @@ impl reexporter::borsh::BorshSchema for A {
         let definition = reexporter::borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: reexporter::borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration()),
-                (discriminant_1 as i64, "Eggs".to_string(), < AEggs > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                reexporter::borsh::BorshSchema > ::declaration()), (discriminant_1 as
+                i64, "Eggs".to_string(), < AEggs as reexporter::borsh::BorshSchema >
+                ::declaration())
             ],
         };
         reexporter::borsh::schema::add_definition(
-            Self::declaration(),
+            <Self as reexporter::borsh::BorshSchema>::declaration(),
             definition,
             definitions,
         );

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -21,10 +21,15 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Bacon".to_string(), < ABacon > ::declaration())
+                (discriminant_0 as i64, "Bacon".to_string(), < ABacon as
+                borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -11,7 +11,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < B > ::declaration(), < A > ::declaration()
+            < B as borsh::BorshSchema > ::declaration(), < A as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "Side", params.join(", "))
     }
@@ -44,12 +45,16 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "Left".to_string(), < SideLeft < A > >
-                ::declaration()), (discriminant_1 as i64, "Right".to_string(), <
-                SideRight < B > > ::declaration())
+                (discriminant_0 as i64, "Left".to_string(), < SideLeft < A > as
+                borsh::BorshSchema > ::declaration()), (discriminant_1 as i64, "Right"
+                .to_string(), < SideRight < B > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "C", params.join(", "))
     }
@@ -45,12 +46,16 @@ where
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (discriminant_0 as i64, "C3".to_string(), < CC3 > ::declaration()),
-                (discriminant_1 as i64, "C4".to_string(), < CC4 < K, V > >
-                ::declaration())
+                (discriminant_0 as i64, "C3".to_string(), < CC3 as borsh::BorshSchema >
+                ::declaration()), (discriminant_1 as i64, "C4".to_string(), < CC4 < K, V
+                > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
     }
 }
 

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -44,7 +44,7 @@ fn declaration(ident_str: &str, cratename: Path, params_for_bounds: Vec<Type>) -
     let mut declaration_params = vec![];
     for type_param in params_for_bounds {
         declaration_params.push(quote! {
-            <#type_param>::declaration()
+            <#type_param as #cratename::BorshSchema>::declaration()
         });
     }
     if declaration_params.is_empty() {

--- a/borsh-derive/src/internals/schema/structs/mod.rs
+++ b/borsh-derive/src/internals/schema/structs/mod.rs
@@ -63,8 +63,8 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
             #struct_fields
             let definition = #cratename::schema::Definition::Struct { fields };
 
-            let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-            #cratename::schema::add_definition(Self::declaration(), definition, definitions);
+            let no_recursion_flag = definitions.get(&<Self as #cratename::BorshSchema>::declaration()).is_none();
+            #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions);
             if no_recursion_flag {
                 #add_definitions_recursively
             }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
@@ -10,7 +10,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < V > ::declaration(), < T::Associated > ::declaration()
+            < V as borsh::BorshSchema > ::declaration(), < T::Associated as
+            borsh::BorshSchema > ::declaration()
         ];
         format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
     }
@@ -30,8 +31,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <T::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
@@ -10,7 +10,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < V > ::declaration(), < < T as TraitName > ::Associated > ::declaration()
+            < V as borsh::BorshSchema > ::declaration(), < < T as TraitName >
+            ::Associated as borsh::BorshSchema > ::declaration()
         ];
         format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
     }
@@ -30,8 +31,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <<T as TraitName>::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
@@ -11,8 +11,9 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < V > ::declaration(), < T > ::declaration(), < < T as TraitName >
-            ::Associated > ::declaration()
+            < V as borsh::BorshSchema > ::declaration(), < T as borsh::BorshSchema >
+            ::declaration(), < < T as TraitName > ::Associated as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
     }
@@ -32,8 +33,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <(
                 <T as TraitName>::Associated,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -7,7 +7,9 @@ where
     U: borsh::BorshSchema,
 {
     fn declaration() -> borsh::schema::Declaration {
-        let params = borsh::__private::maybestd::vec![< U > ::declaration()];
+        let params = borsh::__private::maybestd::vec![
+            < U as borsh::BorshSchema > ::declaration()
+        ];
         format!(r#"{}<{}>"#, "G", params.join(", "))
     }
     fn add_definitions_recursively(
@@ -24,8 +26,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -7,7 +7,9 @@ where
     U: borsh::BorshSchema,
 {
     fn declaration() -> borsh::schema::Declaration {
-        let params = borsh::__private::maybestd::vec![< U > ::declaration()];
+        let params = borsh::__private::maybestd::vec![
+            < U as borsh::BorshSchema > ::declaration()
+        ];
         format!(r#"{}<{}>"#, "G", params.join(", "))
     }
     fn add_definitions_recursively(
@@ -22,8 +24,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "G", params.join(", "))
     }
@@ -27,8 +28,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < U > ::declaration(), < K > ::declaration()
+            < U as borsh::BorshSchema > ::declaration(), < K as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "G", params.join(", "))
     }
@@ -28,8 +29,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
@@ -21,8 +21,14 @@ impl<C> borsh::BorshSchema for ASalad<C> {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <Tomatoes as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <Oil as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
@@ -22,8 +22,14 @@ impl borsh::BorshSchema for CRecC {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <HashMap<

--- a/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
@@ -7,7 +7,9 @@ where
     V: borsh::BorshSchema,
 {
     fn declaration() -> borsh::schema::Declaration {
-        let params = borsh::__private::maybestd::vec![< V > ::declaration()];
+        let params = borsh::__private::maybestd::vec![
+            < V as borsh::BorshSchema > ::declaration()
+        ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
     fn add_definitions_recursively(
@@ -26,8 +28,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <PrimaryMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -29,8 +30,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
@@ -21,8 +21,14 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -22,9 +22,11 @@ impl reexporter::borsh::BorshSchema for A {
         let definition = reexporter::borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
+        let no_recursion_flag = definitions
+            .get(&<Self as reexporter::borsh::BorshSchema>::declaration())
+            .is_none();
         reexporter::borsh::schema::add_definition(
-            Self::declaration(),
+            <Self as reexporter::borsh::BorshSchema>::declaration(),
             definition,
             definitions,
         );

--- a/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
@@ -10,7 +10,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -30,8 +31,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <HashMap<
                 K,

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
@@ -21,8 +21,14 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -28,8 +29,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <V as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
@@ -20,8 +20,14 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
@@ -16,8 +16,14 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {}
     }
 }

--- a/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
@@ -16,8 +16,14 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {}
     }
 }

--- a/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
@@ -9,7 +9,8 @@ where
 {
     fn declaration() -> borsh::schema::Declaration {
         let params = borsh::__private::maybestd::vec![
-            < K > ::declaration(), < V > ::declaration()
+            < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
+            ::declaration()
         ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
@@ -28,8 +29,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             third_party_impl::add_definitions_recursively::<K, V>(definitions);
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);

--- a/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
@@ -7,7 +7,9 @@ where
     T: borsh::BorshSchema,
 {
     fn declaration() -> borsh::schema::Declaration {
-        let params = borsh::__private::maybestd::vec![< T > ::declaration()];
+        let params = borsh::__private::maybestd::vec![
+            < T as borsh::BorshSchema > ::declaration()
+        ];
         format!(r#"{}<{}>"#, "A", params.join(", "))
     }
     fn add_definitions_recursively(
@@ -22,8 +24,14 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions.get(&Self::declaration()).is_none();
-        borsh::schema::add_definition(Self::declaration(), definition, definitions);
+        let no_recursion_flag = definitions
+            .get(&<Self as borsh::BorshSchema>::declaration())
+            .is_none();
+        borsh::schema::add_definition(
+            <Self as borsh::BorshSchema>::declaration(),
+            definition,
+            definitions,
+        );
         if no_recursion_flag {
             <T as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh/tests/test_schema_enums.rs
+++ b/borsh/tests/test_schema_enums.rs
@@ -39,7 +39,14 @@ pub fn simple_enum() {
         Bacon,
         Eggs,
     }
-    assert_eq!("A".to_string(), A::declaration());
+    // https://github.com/near/borsh-rs/issues/112
+    #[allow(unused)]
+    impl A {
+        pub fn declaration() -> usize {
+            42
+        }
+    }
+    assert_eq!("A".to_string(), <A as borsh::BorshSchema>::declaration());
     let mut defs = Default::default();
     A::add_definitions_recursively(&mut defs);
     assert_eq!(

--- a/borsh/tests/test_schema_structs.rs
+++ b/borsh/tests/test_schema_structs.rs
@@ -38,7 +38,15 @@ macro_rules! map(
 pub fn unit_struct() {
     #[derive(borsh::BorshSchema)]
     struct A;
-    assert_eq!("A".to_string(), A::declaration());
+
+    // https://github.com/near/borsh-rs/issues/112
+    #[allow(unused)]
+    impl A {
+        pub fn declaration() -> usize {
+            42
+        }
+    }
+    assert_eq!("A".to_string(), <A as borsh::BorshSchema>::declaration());
     let mut defs = Default::default();
     A::add_definitions_recursively(&mut defs);
     assert_eq!(


### PR DESCRIPTION
resolves #112 , 
which either was not fully resolved by #140 or reemerged later in the process

this is not a breaking change and can be safely included in 1.0.1 release