### PR TITLE
fix: relax `schema_container_of` target requirement with `?Sized` to allow slices

### DIFF
--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -178,7 +178,7 @@ impl Attributes {
     }
     pub(crate) fn collect_bounds(&self, ty: BoundType) -> Vec<WherePredicate> {
         let predicates = self.get_bounds(ty);
-        predicates.unwrap_or(vec![])
+        predicates.unwrap_or_default()
     }
 }
 

--- a/borsh/src/schema.rs
+++ b/borsh/src/schema.rs
@@ -169,7 +169,7 @@ impl BorshSchemaContainer {
     }
 
     /// generate [BorshSchemaContainer] for type `T`
-    pub fn for_type<T: BorshSchema>() -> Self {
+    pub fn for_type<T: BorshSchema + ?Sized>() -> Self {
         let mut definitions = Default::default();
         T::add_definitions_recursively(&mut definitions);
         Self::new(T::declaration(), definitions)

--- a/borsh/src/schema_helpers.rs
+++ b/borsh/src/schema_helpers.rs
@@ -20,7 +20,9 @@ pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -
 
 /// Serialize object into a vector of bytes and prefix with the schema serialized as vector of
 /// bytes in Borsh format.
-pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema>(value: &T) -> Result<Vec<u8>> {
+pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema + ?Sized>(
+    value: &T,
+) -> Result<Vec<u8>> {
     let schema = schema_container_of::<T>();
     let mut res = crate::to_vec(&schema)?;
     value.serialize(&mut res)?;
@@ -30,7 +32,7 @@ pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema>(value: &T) -> Res
 /// generate [BorshSchemaContainer] for type `T`
 ///
 /// this is an alias of [BorshSchemaContainer::for_type]
-pub fn schema_container_of<T: BorshSchema>() -> BorshSchemaContainer {
+pub fn schema_container_of<T: BorshSchema + ?Sized>() -> BorshSchemaContainer {
     BorshSchemaContainer::for_type::<T>()
 }
 
@@ -44,7 +46,7 @@ pub fn schema_container_of<T: BorshSchema>() -> BorshSchemaContainer {
 ///
 /// assert_eq!(Ok(8), borsh::max_serialized_size::<usize>());
 /// ```
-pub fn max_serialized_size<T: BorshSchema>(
+pub fn max_serialized_size<T: BorshSchema + ?Sized>(
 ) -> core::result::Result<usize, SchemaMaxSerializedSizeError> {
     let schema = BorshSchemaContainer::for_type::<T>();
     schema.max_serialized_size()

--- a/borsh/tests/test_schema_vec.rs
+++ b/borsh/tests/test_schema_vec.rs
@@ -1,0 +1,68 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg(hash_collections)]
+#![cfg(feature = "unstable__schema")]
+
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::ToString};
+
+use borsh::{schema::*, schema_container_of};
+
+macro_rules! map(
+    () => { BTreeMap::new() };
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = BTreeMap::new();
+            $(
+                m.insert($key.to_string(), $value);
+            )+
+            m
+        }
+     };
+);
+
+#[test]
+fn slice_schema_container() {
+    let schema = schema_container_of::<[i64]>();
+
+    assert_eq!(
+        schema,
+        BorshSchemaContainer::new(
+            "Vec<i64>".to_string(),
+            map! {
+                "Vec<i64>" => Definition::Sequence {
+                    length_width: Definition::DEFAULT_LENGTH_WIDTH,
+                    length_range: Definition::DEFAULT_LENGTH_RANGE,
+                    elements: "i64".to_string(),
+                },
+                "i64" => Definition::Primitive(8)
+
+            }
+        )
+    )
+}
+
+#[test]
+fn vec_schema_container() {
+    let schema = schema_container_of::<Vec<i64>>();
+
+    assert_eq!(
+        schema,
+        BorshSchemaContainer::new(
+            "Vec<i64>".to_string(),
+            map! {
+                "Vec<i64>" => Definition::Sequence {
+                    length_width: Definition::DEFAULT_LENGTH_WIDTH,
+                    length_range: Definition::DEFAULT_LENGTH_RANGE,
+                    elements: "i64".to_string(),
+                },
+                "i64" => Definition::Primitive(8)
+
+            }
+        )
+    )
+}


### PR DESCRIPTION
this blocks 
```rust
#[near_bindgen]
impl Contract {
    pub fn foo(
        &self,
        #[serializer(borsh)]
        c: &[bool],
    ) {}
}
```

it has been tested in cargo-near#109 with
```
[patch.crates-io]
borsh = { git = 'https://github.com/near/borsh-rs.git', branch = "slice_schema_container" }
```
that this patch works