### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/near/borsh-rs/compare/borsh-v1.0.0...borsh-v1.1.0) - 2023-10-13
+
+### Added
+- relax `schema_container_of` target requirement with `?Sized` to allow slices ([#245](https://github.com/near/borsh-rs/pull/245))
+
+### Fixed
+- fully qualify `#cratename::BorshSchema` in derive-generated code to void function name collisions leading to compilation errors ([#244](https://github.com/near/borsh-rs/pull/244))
+
 ## [1.0.0](https://github.com/near/borsh-rs/compare/borsh-v0.10.3...borsh-v1.0.0) - 2023-10-03
 
 > The year is 2653 and the best yet-to-be citizens of the Terran Federation are fighting 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.0.0"
+version = "1.1.0"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["std", "unstable__schema"]
 cfg_aliases = "0.1.0"
 
 [dependencies]
-borsh-derive = { path = "../borsh-derive", version = "~1.0.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.1.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get 


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.0.0 -> 1.1.0 (✓ API compatible changes)
* `borsh-derive`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.1.0](https://github.com/near/borsh-rs/compare/borsh-v1.0.0...borsh-v1.1.0) - 2023-10-13

### Added
- relax `schema_container_of` target requirement with `?Sized` to allow slices ([#245](https://github.com/near/borsh-rs/pull/245))

### Fixed
- fully qualify `#cratename::BorshSchema` in derive-generated code to void function name collisions leading to compilation errors ([#244](https://github.com/near/borsh-rs/pull/244))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).