### PR TITLE
chore!: don’t unnecessarily add types recursively in `borsh::BorshSchema` derives

### DIFF
--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -66,13 +66,14 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
     let type_definitions = quote! {
         fn add_definitions_recursively(definitions: &mut #cratename::__private::maybestd::collections::BTreeMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
             #inner_defs
-            #add_recursive_defs
             #(#discriminant_variables)*
             let definition = #cratename::schema::Definition::Enum {
                 tag_width: 1,
                 variants: #cratename::__private::maybestd::vec![#(#variants_defs),*],
             };
-            #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions);
+            if #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions) {
+                #add_recursive_defs
+            }
         }
     };
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
@@ -36,12 +36,6 @@ impl borsh::BorshSchema for X {
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
         struct XF;
-        <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let discriminant_2: u8 = 2u8;
@@ -61,11 +55,18 @@ impl borsh::BorshSchema for X {
                 .to_string(), < XF as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
@@ -36,12 +36,6 @@ impl borsh::BorshSchema for X {
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
         struct XF;
-        <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0;
         let discriminant_1: u8 = 20;
         let discriminant_2: u8 = 20 + 1;
@@ -61,11 +55,18 @@ impl borsh::BorshSchema for X {
                 .to_string(), < XF as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -31,10 +31,6 @@ impl borsh::BorshSchema for A {
             wrapper: Wrapper,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let discriminant_2: u8 = 2u8;
@@ -50,11 +46,16 @@ impl borsh::BorshSchema for A {
                 .to_string(), < ASausage as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -39,10 +39,6 @@ where
             wrapper: W,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let discriminant_2: u8 = 2u8;
@@ -58,11 +54,18 @@ where
                 .to_string(), < ASausage < W > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASausage<
+                W,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -41,10 +41,6 @@ where
             filling: Filling,
             unexpected: U,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W, U> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let discriminant_2: u8 = 2u8;
@@ -61,11 +57,19 @@ where
                 ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASausage<
+                W,
+                U,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -41,10 +41,6 @@ where
             wrapper: W,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let discriminant_2: u8 = 2u8;
@@ -60,11 +56,18 @@ where
                 .to_string(), < ASausage < W > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ASausage<
+                W,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -27,8 +27,6 @@ impl borsh::BorshSchema for A {
         struct ANegative {
             beta: String,
         }
-        <AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -39,11 +37,14 @@ impl borsh::BorshSchema for A {
                 ANegative as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -49,13 +49,6 @@ where
         )
         where
             T: Eq + Hash;
-        <EnumParametrizedB<
-            K,
-            V,
-        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <EnumParametrizedC<
-            T,
-        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -67,11 +60,19 @@ where
                 ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <EnumParametrizedB<
+                K,
+                V,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <EnumParametrizedC<
+                T,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -50,13 +50,6 @@ where
         )
         where
             T: Eq + Hash;
-        <EnumParametrizedB<
-            K,
-            V,
-        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <EnumParametrizedC<
-            T,
-        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -68,11 +61,19 @@ where
                 ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <EnumParametrizedB<
+                K,
+                V,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <EnumParametrizedC<
+                T,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -35,8 +35,6 @@ where
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
         struct AC<K: Key>(K, Vec<A>);
-        <AB<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AC<K> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -47,11 +45,14 @@ where
                 .to_string(), < AC < K > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <AB<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AC<K> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -20,8 +20,6 @@ impl borsh::BorshSchema for A {
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
         struct AEggs;
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -32,11 +30,14 @@ impl borsh::BorshSchema for A {
                 .to_string(), < AEggs as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -20,12 +20,6 @@ impl reexporter::borsh::BorshSchema for A {
         #[derive(reexporter::borsh::BorshSchema)]
         #[borsh(crate = "reexporter :: borsh")]
         struct AEggs;
-        <ABacon as reexporter::borsh::BorshSchema>::add_definitions_recursively(
-            definitions,
-        );
-        <AEggs as reexporter::borsh::BorshSchema>::add_definitions_recursively(
-            definitions,
-        );
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = reexporter::borsh::schema::Definition::Enum {
@@ -37,11 +31,18 @@ impl reexporter::borsh::BorshSchema for A {
                 ::declaration())
             ],
         };
-        reexporter::borsh::schema::add_definition(
+        if reexporter::borsh::schema::add_definition(
             <Self as reexporter::borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as reexporter::borsh::BorshSchema>::add_definitions_recursively(
+                definitions,
+            );
+            <AEggs as reexporter::borsh::BorshSchema>::add_definitions_recursively(
+                definitions,
+            );
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -16,7 +16,6 @@ impl borsh::BorshSchema for A {
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
         struct ABacon;
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
@@ -25,11 +24,13 @@ impl borsh::BorshSchema for A {
                 borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -38,8 +38,6 @@ where
         )
         where
             B: Display + Debug;
-        <SideLeft<A> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <SideRight<B> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -50,11 +48,18 @@ where
                 .to_string(), < SideRight < B > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <SideLeft<
+                A,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <SideRight<
+                B,
+            > as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -39,8 +39,6 @@ where
             )]
             ThirdParty<K, V>,
         );
-        <CC3 as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <CC4<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let discriminant_0: u8 = 0u8;
         let discriminant_1: u8 = 1u8;
         let definition = borsh::schema::Definition::Enum {
@@ -51,11 +49,14 @@ where
                 > as borsh::BorshSchema > ::declaration())
             ],
         };
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
+        ) {
+            <CC3 as borsh::BorshSchema>::add_definitions_recursively(definitions);
+            <CC4<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
     }
 }
 

--- a/borsh-derive/src/internals/schema/structs/mod.rs
+++ b/borsh-derive/src/internals/schema/structs/mod.rs
@@ -6,7 +6,7 @@ use crate::internals::{attributes::field, generics, schema};
 
 /// function which computes derive output [proc_macro2::TokenStream]
 /// of code, which computes declaration of a single field, which is later added to
-/// the struct's definition as a whole  
+/// the struct's definition as a whole
 fn field_declaration_output(
     field_name: Option<&Ident>,
     field_type: &Type,
@@ -62,10 +62,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
         fn add_definitions_recursively(definitions: &mut #cratename::__private::maybestd::collections::BTreeMap<#cratename::schema::Declaration, #cratename::schema::Definition>) {
             #struct_fields
             let definition = #cratename::schema::Definition::Struct { fields };
-
-            let no_recursion_flag = definitions.get(&<Self as #cratename::BorshSchema>::declaration()).is_none();
-            #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions);
-            if no_recursion_flag {
+            if #cratename::schema::add_definition(<Self as #cratename::BorshSchema>::declaration(), definition, definitions) {
                 #add_definitions_recursively
             }
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
@@ -31,15 +31,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <T::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,
             );

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
@@ -31,15 +31,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <<T as TraitName>::Associated as borsh::BorshSchema>::add_definitions_recursively(
                 definitions,
             );

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
@@ -33,15 +33,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <(
                 <T as TraitName>::Associated,
                 T,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -26,15 +26,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }
     }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -24,15 +24,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }
     }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -28,15 +28,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <HashMap<
                 K,
                 V,

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
@@ -29,15 +29,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <U as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
@@ -21,15 +21,11 @@ impl<C> borsh::BorshSchema for ASalad<C> {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <Tomatoes as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <Oil as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
@@ -22,15 +22,11 @@ impl borsh::BorshSchema for CRecC {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <HashMap<
                 String,

--- a/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
@@ -28,15 +28,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <PrimaryMap<
                 K,
                 V,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
@@ -30,15 +30,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <HashMap<
                 K,
                 V,

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
@@ -21,15 +21,11 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -22,15 +22,11 @@ impl reexporter::borsh::BorshSchema for A {
         let definition = reexporter::borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as reexporter::borsh::BorshSchema>::declaration())
-            .is_none();
-        reexporter::borsh::schema::add_definition(
+        if reexporter::borsh::schema::add_definition(
             <Self as reexporter::borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <u64 as reexporter::borsh::BorshSchema>::add_definitions_recursively(
                 definitions,
             );

--- a/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
@@ -31,15 +31,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <HashMap<
                 K,
                 V,

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
@@ -21,15 +21,11 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
@@ -29,15 +29,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <K as borsh::BorshSchema>::add_definitions_recursively(definitions);
             <V as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
@@ -20,15 +20,11 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <String as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }
     }

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
@@ -16,15 +16,11 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {}
+        ) {}
     }
 }
 

--- a/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
@@ -16,15 +16,11 @@ impl borsh::BorshSchema for A {
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {}
+        ) {}
     }
 }
 

--- a/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
@@ -29,15 +29,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             third_party_impl::add_definitions_recursively::<K, V>(definitions);
             <u64 as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }

--- a/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
@@ -24,15 +24,11 @@ where
         let definition = borsh::schema::Definition::Struct {
             fields,
         };
-        let no_recursion_flag = definitions
-            .get(&<Self as borsh::BorshSchema>::declaration())
-            .is_none();
-        borsh::schema::add_definition(
+        if borsh::schema::add_definition(
             <Self as borsh::BorshSchema>::declaration(),
             definition,
             definitions,
-        );
-        if no_recursion_flag {
+        ) {
             <T as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }
     }

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -925,9 +925,7 @@ mod index_map_impl {
             let definition = Definition::Sequence {
                 elements: <(K, V)>::declaration(),
             };
-            let no_recursion_flag = definitions.get(&declaration::<K, V>()).is_none();
-            <() as BorshSchema>::add_definition(declaration::<K, V>(), definition, definitions);
-            if no_recursion_flag {
+            if <() as BorshSchema>::add_definition(declaration::<K, V>(), definition, definitions) {
                 <(K, V)>::add_definitions_recursively(definitions);
             }
         }

--- a/borsh/src/schema/container_ext/max_size.rs
+++ b/borsh/src/schema/container_ext/max_size.rs
@@ -447,9 +447,10 @@ mod tests {
                         (1, "Nothing".into(), <()>::declaration()),
                     ],
                 };
-                crate::schema::add_definition(Self::declaration(), definition, definitions);
-                T::add_definitions_recursively(definitions);
-                <()>::add_definitions_recursively(definitions);
+                if crate::schema::add_definition(Self::declaration(), definition, definitions) {
+                    T::add_definitions_recursively(definitions);
+                    <()>::add_definitions_recursively(definitions);
+                }
             }
         }
 
@@ -481,8 +482,9 @@ mod tests {
                     length_range: 0..=N,
                     elements: "u8".to_string(),
                 };
-                crate::schema::add_definition(Self::declaration(), definition, definitions);
-                u8::add_definitions_recursively(definitions);
+                if crate::schema::add_definition(Self::declaration(), definition, definitions) {
+                    u8::add_definitions_recursively(definitions);
+                }
             }
         }
 
@@ -514,8 +516,9 @@ mod tests {
                     length_range: 0..=u8::MAX as u64,
                     elements: T::declaration(),
                 };
-                crate::schema::add_definition(Self::declaration(), definition, definitions);
-                T::add_definitions_recursively(definitions);
+                if crate::schema::add_definition(Self::declaration(), definition, definitions) {
+                    T::add_definitions_recursively(definitions);
+                }
             }
         }
 

--- a/borsh/tests/test_schema_conflict.rs
+++ b/borsh/tests/test_schema_conflict.rs
@@ -1,0 +1,177 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg(feature = "unstable__schema")]
+
+#[cfg(feature = "std")]
+use std::collections::{BTreeMap, BTreeSet};
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::ToString,
+    vec::Vec,
+};
+
+use borsh::schema::{add_definition, Declaration, Definition, Fields};
+use borsh::BorshSchema;
+
+struct ConflictingSchema;
+
+impl BorshSchema for ConflictingSchema {
+    #[inline]
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let fields = Fields::Empty;
+        let def = Definition::Struct { fields };
+        add_definition(Self::declaration(), def, definitions);
+    }
+    #[inline]
+    fn declaration() -> Declaration {
+        "i64".into()
+    }
+}
+
+#[test]
+#[should_panic(expected = "Redefining type schema for i64")]
+fn test_conflict() {
+    let mut defs = Default::default();
+    <Vec<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+
+    <ConflictingSchema as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+}
+
+#[test]
+fn test_implicit_conflict_vec() {
+    let mut defs = Default::default();
+    <Vec<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <Vec<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_range() {
+    let mut defs = Default::default();
+    <core::ops::Range<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <core::ops::Range<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(
+        &mut defs,
+    );
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_slice() {
+    let mut defs = Default::default();
+    <[i64] as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <[ConflictingSchema] as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_array() {
+    let mut defs = Default::default();
+    <[i64; 10] as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <[ConflictingSchema; 10] as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_option() {
+    let mut defs = Default::default();
+    <Option<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <Option<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[allow(unused)]
+#[derive(borsh::BorshSchema)]
+struct GenericStruct<T> {
+    field: T,
+}
+
+#[test]
+fn test_implicit_conflict_struct() {
+    let mut defs = Default::default();
+    <GenericStruct<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <GenericStruct<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(
+        &mut defs,
+    );
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+    // this loophole is needed to enable derives for recursive structs/enums
+}
+
+#[allow(unused)]
+#[derive(borsh::BorshSchema)]
+struct SelfConflictingStruct {
+    field_1: i64,
+    field_2: ConflictingSchema,
+}
+
+#[test]
+#[should_panic(expected = "Redefining type schema for i64")]
+fn test_implicit_conflict_self_conflicting_struct() {
+    let mut defs = Default::default();
+    <SelfConflictingStruct as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+}
+
+#[allow(unused)]
+#[derive(borsh::BorshSchema)]
+enum GenericEnum<T> {
+    A { field: T },
+    B(u64),
+}
+
+#[test]
+fn test_implicit_conflict_enum() {
+    let mut defs = Default::default();
+    <GenericEnum<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <GenericEnum<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+    // this loophole is needed to enable derives for recursive structs/enums
+}
+
+#[allow(unused)]
+#[derive(borsh::BorshSchema)]
+enum SelfConflictingEnum {
+    A { field: i64 },
+    B { field: ConflictingSchema },
+}
+
+#[test]
+#[should_panic(expected = "Redefining type schema for i64")]
+fn test_implicit_conflict_self_conflicting_enum() {
+    let mut defs = Default::default();
+    <SelfConflictingEnum as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+}
+
+#[test]
+fn test_implicit_conflict_result() {
+    let mut defs = Default::default();
+    <Result<u8, i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <Result<u8, ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_btreemap() {
+    let mut defs = Default::default();
+    <BTreeMap<i64, u8> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <BTreeMap<ConflictingSchema, u8> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_btreeset() {
+    let mut defs = Default::default();
+    <BTreeSet<i64> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <BTreeSet<ConflictingSchema> as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}
+
+#[test]
+fn test_implicit_conflict_tuple() {
+    let mut defs = Default::default();
+    <(i64, u8) as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    <(ConflictingSchema, u8) as borsh::BorshSchema>::add_definitions_recursively(&mut defs);
+    // NOTE: the contents of `defs` depend on the order of 2 above lines
+}

--- a/borsh/tests/test_schema_validate.rs
+++ b/borsh/tests/test_schema_validate.rs
@@ -84,8 +84,9 @@ fn max_serialized_size_bound_vec() {
                 length_range: 0..=N,
                 elements: "u8".to_string(),
             };
-            add_definition(Self::declaration(), definition, definitions);
-            u8::add_definitions_recursively(definitions);
+            if add_definition(Self::declaration(), definition, definitions) {
+                u8::add_definitions_recursively(definitions);
+            }
         }
     }
 

--- a/borsh/tests/test_schema_with.rs
+++ b/borsh/tests/test_schema_with.rs
@@ -63,9 +63,7 @@ mod third_party_impl {
             <BTreeMap<K, V> as borsh::BorshSchema>::declaration(),
         ]);
         let definition = borsh::schema::Definition::Struct { fields };
-        let no_recursion_flag = definitions.get(&declaration::<K, V>()).is_none();
-        borsh::schema::add_definition(declaration::<K, V>(), definition, definitions);
-        if no_recursion_flag {
+        if borsh::schema::add_definition(declaration::<K, V>(), definition, definitions) {
             <BTreeMap<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         }
     }


### PR DESCRIPTION
Firstly, change add_definition function to return whether the
definition has been added or it already existed in the map.  This
avoids double map lookup in places which conditionally add component
definitions.

Secondly, use the check consistently in all places so that component
definitions aren’t processed unnecessarily.

---
NOTE: formally, this is a breaking change, as `borsh-derive` with this change of version, say, `1.2.0` won't be compatible with `borsh` `1.1.0`. Hopefully, [tilde version requirement](https://github.com/near/borsh-rs/blob/master/borsh/Cargo.toml#L30) adresses this problem.
