### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/near/borsh-rs/compare/borsh-v1.2.1...borsh-v1.3.0) - 2023-12-07
+
+### Added
+- impl `BorshSchema` for `Rc` and `Arc`; add doc for `rc` feature ([#268](https://github.com/near/borsh-rs/pull/268))
+
 ## [1.2.1](https://github.com/near/borsh-rs/compare/borsh-v1.2.0...borsh-v1.2.1) - 2023-12-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.2.1"
+version = "1.3.0"
 rust-version = "1.66.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -28,7 +28,7 @@ cfg_aliases = "0.1.0"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.2.1", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.3.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.2.1 -> 1.3.0 (✓ API compatible changes)
* `borsh-derive`: 1.2.1 -> 1.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.3.0](https://github.com/near/borsh-rs/compare/borsh-v1.2.1...borsh-v1.3.0) - 2023-12-07

### Added
- impl `BorshSchema` for `Rc` and `Arc`; add doc for `rc` feature ([#268](https://github.com/near/borsh-rs/pull/268))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).