### PR TITLE
feat: add `derive_use_cargo` default feature

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -14,6 +14,7 @@ cargo test --test test_hash_map --test test_btree_map --features de_strict_order
 cargo test --no-default-features
 cargo test --no-default-features --features unstable__schema,ascii --test test_ascii_strings
 cargo test --no-default-features --features derive
+cargo test --no-default-features --features derive,derive_use_cargo
 cargo test --no-default-features --features unstable__schema
 cargo test --no-default-features --test test_rc --features unstable__schema,rc
 cargo test --no-default-features --features hashbrown

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "2", features = ["full", "fold"] }
-proc-macro-crate = "2"
+proc-macro-crate = { version = "2", optional = true }
 proc-macro2 = "1"
 quote = "1"
 once_cell = "1.18.0"
@@ -36,6 +36,6 @@ features = ["schema"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = []
+default = ["proc-macro-crate"]
 schema = []
 force_exhaustive_checks = []

--- a/borsh-derive/src/internals/cratename.rs
+++ b/borsh-derive/src/internals/cratename.rs
@@ -1,4 +1,5 @@
 use proc_macro2::Span;
+#[cfg(feature = "proc-macro-crate")]
 use proc_macro_crate::{crate_name, FoundCrate};
 use syn::{Attribute, Error, Ident, Path};
 
@@ -11,12 +12,16 @@ pub(crate) fn get(attrs: &[Attribute]) -> Result<Path, Error> {
     match path {
         Some(path) => Ok(path),
         None => {
+            #[cfg(feature = "proc-macro-crate")]
             let ident = get_from_cargo();
+            #[cfg(not(feature = "proc-macro-crate"))]
+            let ident = static_string();
             Ok(ident.into())
         }
     }
 }
 
+#[cfg(feature = "proc-macro-crate")]
 pub(crate) fn get_from_cargo() -> Ident {
     let name = &crate_name(BORSH).unwrap();
     let name = match name {
@@ -24,4 +29,9 @@ pub(crate) fn get_from_cargo() -> Ident {
         FoundCrate::Name(name) => name.as_str(),
     };
     Ident::new(name, Span::call_site())
+}
+
+#[cfg(not(feature = "proc-macro-crate"))]
+pub(crate) fn static_string() -> Ident {
+    Ident::new(BORSH, Span::call_site())
 }

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -73,20 +73,28 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided:
 
-```bash
- 1  error: proc-macro derive panicked
-   --> path/to/file.rs:27:10
-    |
- 27 | #[derive(BorshSerialize, BorshDeserialize)]
-    |          ^^^^^^^^^^^^^^
-    |
-    = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
-```
+  - If `proc-macro-crate` feature of `borsh-derive`, which is controlled by `derive_use_cargo` feature
+    of `borsh`, is enabled, then
+    [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
+    in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
-2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped.
+    ```bash
+     1  error: proc-macro derive panicked
+       --> path/to/file.rs:27:10
+        |
+     27 | #[derive(BorshSerialize, BorshDeserialize)]
+        |          ^^^^^^^^^^^^^^
+        |
+        = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
+    ```
+
+  - If `proc-macro-crate` feature of `borsh-derive` is disabled, the path to `borsh` is assumed to be simply `borsh`.
+    The feature can be opted out of to remove dependency on `cargo` in build process.
+
+2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped
+   and the provided attribute value is used instead.
 
 Examples of usage:
 
@@ -360,20 +368,28 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided:
 
-```bash
- 1  error: proc-macro derive panicked
-   --> path/to/file.rs:27:10
-    |
- 27 | #[derive(BorshDeserialize, BorshSerialize)]
-    |          ^^^^^^^^^^^^^^^^
-    |
-    = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
-```
+  - If `proc-macro-crate` feature of `borsh-derive`, which is controlled by `derive_use_cargo` feature
+    of `borsh`, is enabled, then
+    [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
+    in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
-2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped.
+    ```bash
+     1  error: proc-macro derive panicked
+       --> path/to/file.rs:27:10
+        |
+     27 | #[derive(BorshDeserialize, BorshSerialize)]
+        |          ^^^^^^^^^^^^^^^^
+        |
+        = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
+    ```
+
+  - If `proc-macro-crate` feature of `borsh-derive` is disabled, the path to `borsh` is assumed to be simply `borsh`.
+    The feature can be opted out of to remove dependency on `cargo` in build process.
+
+2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped
+   and the provided attribute value is used instead.
 
 Examples of usage:
 
@@ -696,20 +712,28 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided:
 
-```bash
- 1  error: proc-macro derive panicked
-   --> path/to/file.rs:27:10
-    |
- 27 | #[derive(BorshSchema, BorshSerialize)]
-    |          ^^^^^^^^^^^
-    |
-    = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
-```
+  - If `proc-macro-crate` feature of `borsh-derive`, which is controlled by `derive_use_cargo` feature
+    of `borsh`, is enabled, then
+    [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
+    in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
-2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped.
+    ```bash
+     1  error: proc-macro derive panicked
+       --> path/to/file.rs:27:10
+        |
+     27 | #[derive(BorshSchema, BorshSerialize)]
+        |          ^^^^^^^^^^^
+        |
+        = help: message: called `Result::unwrap()` on an `Err` value: CrateNotFound { crate_name: "borsh", path: "/path/to/Cargo.toml" }
+    ```
+
+  - If `proc-macro-crate` feature of `borsh-derive` is disabled, the path to `borsh` is assumed to be simply `borsh`.
+    The feature can be opted out of to remove dependency on `cargo` in build process.
+
+2. If the attribute is provided, the check for `borsh` in `[dependencies]` of the relevant `Cargo.toml` is skipped
+   and the provided attribute value is used instead.
 
 Examples of usage:
 

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -28,7 +28,7 @@ cfg_aliases = "0.1.0"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.2.1", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.2.1", optional = true , default_features = false}
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get
@@ -49,7 +49,7 @@ features = ["derive", "unstable__schema", "rc"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["std"]
+default = ["std", "derive_use_cargo"]
 derive = ["borsh-derive"]
 unstable__schema = ["derive", "borsh-derive/schema"]
 std = []
@@ -58,3 +58,4 @@ std = []
 # Be sure that this is what you want before enabling this feature.
 rc = []
 de_strict_order = []
+derive_use_cargo = ["borsh-derive?/proc-macro-crate"]

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -20,13 +20,19 @@
 
 ### Default features
 
-* **std** - enabled by default.
+* **std** , **derive_use_cargo** - enabled by default.
 
 ### Other features
 
 * **derive** -
   Gates derive macros of [BorshSerialize] and
   [BorshDeserialize] traits.
+* **derive_use_cargo** -
+  Enables `proc-macro-crate` feature of `borsh-derive` dependency, which tracks `borsh`
+  crate rename in `Cargo.toml` via `cargo`.
+
+  This feature has effect only if **derive** feature  is enabled.
+  More details are mentioned in `#[borsh(crate = ...)]` attribute description in [borsh_derive] doc.
 * **unstable__schema** -
   Gates [BorshSchema] trait and its derive macro.
   Gates [schema] module.


### PR DESCRIPTION
resolves #271

a way to disable `proc-macro-crate`  (it depends on `cargo` binary being available) without annotating each derive with tautological `#[borsh(crate = "borsh")]` 

[sample1, derive_use_cargo : default features](https://github.com/dj8yfo/sample1/blob/master/Cargo.toml)
[sample1 : `proc-macro-crate`  dependency in `Cargo.lock`](https://github.com/dj8yfo/sample1/blob/master/Cargo.lock#L20)

[sample2, derive_no_use_cargo : opt-out of `derive_use_cargo` feature](https://github.com/dj8yfo/sample2/blob/master/Cargo.toml)
[sample2 : `proc-macro-crate`  dependency absent in `Cargo.lock`](https://github.com/dj8yfo/sample2/blob/master/Cargo.lock#L18-L24)

--- 
NOTE:  this change causes breakage for `no_std` projects with `borsh` dependency renamed - [sample3, derive_no_std_rename_breakage](https://github.com/dj8yfo/sample3/blob/fb9b06853d1902fab40c9f62a1a2e03f345b8860/Cargo.toml)
This commit [breaks](https://github.com/dj8yfo/sample3/commit/596adce85269b28cbc1db6f755ed09666f9543a3)
compilation on version update, and this [fixes](https://github.com/dj8yfo/sample3/commit/c0b6568105c32746b183bb1573eb8fa0ff403a19) it.



