### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.5.0"
+version = "1.6.0"
 rust-version = "1.67.0"

--- a/borsh-derive/CHANGELOG.md
+++ b/borsh-derive/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-derive-v1.5.0...borsh-derive-v1.6.0) - 2024-05-30
+
+### Fixed
+- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))

--- a/borsh/CHANGELOG.md
+++ b/borsh/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.6.0) - 2024-05-30
+
+### Added
+- *(schema)* for `HashMap<K, V>` -> `HashMap<K, V, S>`, for `HashSet<T>` -> `HashSet<T, S>` ([#294](https://github.com/near/borsh-rs/pull/294))
+
+### Fixed
+- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -28,7 +28,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.5.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.5.0 -> 1.6.0
* `borsh-derive`: 1.5.0 -> 1.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.6.0) - 2024-05-30

### Added
- *(schema)* for `HashMap<K, V>` -> `HashMap<K, V, S>`, for `HashSet<T>` -> `HashSet<T, S>` ([#294](https://github.com/near/borsh-rs/pull/294))

### Fixed
- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))
</blockquote>

## `borsh-derive`
<blockquote>

## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-derive-v1.5.0...borsh-derive-v1.6.0) - 2024-05-30

### Fixed
- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).