### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.6.0) - 2024-05-30
+
+### Added
+- *(schema)* for `HashMap<K, V>` -> `HashMap<K, V, S>`, for `HashSet<T>` -> `HashSet<T, S>` ([#294](https://github.com/near/borsh-rs/pull/294))
+
+### Fixed
+- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))
+
 ## [1.5.0](https://github.com/near/borsh-rs/compare/borsh-v1.4.0...borsh-v1.5.0) - 2024-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.6.0) - 2024-05-30
+## [1.5.1](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.5.1) - 2024-05-30
 
 ### Added
 - *(schema)* for `HashMap<K, V>` -> `HashMap<K, V, S>`, for `HashSet<T>` -> `HashSet<T, S>` ([#294](https://github.com/near/borsh-rs/pull/294))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.6.0"
+version = "1.5.1"
 rust-version = "1.67.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.5.0"
+version = "1.6.0"
 rust-version = "1.67.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -28,7 +28,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.5.1", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -28,7 +28,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.5.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.5.0 -> 1.5.1
* `borsh-derive`: 1.5.0 -> 1.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.5.1](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.5.1) - 2024-05-30

### Added
- *(schema)* for `HashMap<K, V>` -> `HashMap<K, V, S>`, for `HashSet<T>` -> `HashSet<T, S>` ([#294](https://github.com/near/borsh-rs/pull/294))

### Fixed
- fixed linting warnings for Rust 1.78 stable,  1.80 nightly ([#295](https://github.com/near/borsh-rs/pull/295))
</blockquote>


</p></details>

---
This PR was generated semi-automatically with [release-plz](https://github.com/MarcoIeni/release-plz/) and @dj8yfo 