### PR TITLE
feat: Forbid Vectors of Zero-sized types from de-/serialization to resolve the RUSTSEC-2023-0033 (#145)

### DIFF
--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -1,12 +1,13 @@
 use core::convert::TryFrom;
 use core::hash::BuildHasher;
 use core::marker::PhantomData;
+use core::mem::size_of;
 
 use crate::maybestd::{
     borrow::{Cow, ToOwned},
     boxed::Box,
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    io::{ErrorKind, Result, Write},
+    io::{Error, ErrorKind, Result, Write},
     string::String,
     vec::Vec,
 };
@@ -267,6 +268,12 @@ where
 {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        if size_of::<T>() == 0 {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Vectors of zero-sized types are not allowed due to deny-of-service concerns on deserialization.",
+            ));
+        }
         self.as_slice().serialize(writer)
     }
 }

--- a/borsh/tests/test_zero_size.rs
+++ b/borsh/tests/test_zero_size.rs
@@ -1,11 +1,36 @@
+use borsh::to_vec;
 use borsh::BorshDeserialize;
+use borsh::BorshSerialize;
 
-#[derive(BorshDeserialize, PartialEq, Debug)]
-struct A;
+#[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
+struct A();
 
 #[test]
-fn test_deserialize_vector_to_many_zero_size_struct() {
+fn test_deserialize_zero_size() {
     let v = [0u8, 0u8, 0u8, 64u8];
-    let a = Vec::<A>::try_from_slice(&v).unwrap();
-    assert_eq!(A {}, a[usize::pow(2, 30) - 1])
+    let res = Vec::<A>::try_from_slice(&v);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_serialize_zero_size() {
+    let v = vec![A()];
+    let res = to_vec(&v);
+    assert!(res.is_err());
+}
+
+#[derive(BorshDeserialize, BorshSerialize, PartialEq, Debug)]
+struct B(u32);
+#[test]
+fn test_deserialize_non_zero_size() {
+    let v = [1, 0, 0, 0, 64, 0, 0, 0];
+    let res = Vec::<B>::try_from_slice(&v);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_serialize_non_zero_size() {
+    let v = vec![B(1)];
+    let res = to_vec(&v);
+    assert!(res.is_ok());
 }


### PR DESCRIPTION
This is a backport of commit e880d8786cb16aa9a3f258e7503932445d708df7.