### PR TITLE
feat(schema)!: prepend module to declarations in `BorshSchema` 

### DIFF
--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -117,7 +117,7 @@ fn process_variant(
     generics_output: &mut schema::GenericsOutput,
 ) -> syn::Result<VariantOutput> {
     let variant_name = variant.ident.to_token_stream().to_string();
-    let full_variant_name = format!("{}{}", enum_name, variant_name);
+    let full_variant_name = format!("___{}{}", enum_name, variant_name);
     let full_variant_ident = Ident::new(&full_variant_name, Span::call_site());
 
     schema::visit_struct_fields(&variant.fields, &mut generics_output.params_visitor)?;

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for X {
     fn declaration() -> borsh::schema::Declaration {
-        "X".to_string()
+        format!("{}::{}", std::module_path!(), "X")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -62,4 +62,3 @@ impl borsh::BorshSchema for X {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
@@ -15,44 +15,44 @@ impl borsh::BorshSchema for X {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XA;
+        struct ___XA;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XB;
+        struct ___XB;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XC;
+        struct ___XC;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XD;
+        struct ___XD;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XE;
+        struct ___XE;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XF;
-        <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        struct ___XF;
+        <___XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "A".into(), < XA as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "B".into(), < XB as
+                (u8::from(0u8) as i64, "A".into(), < ___XA as borsh::BorshSchema >
+                ::declaration()), (u8::from(1u8) as i64, "B".into(), < ___XB as
                 borsh::BorshSchema > ::declaration()), (u8::from(2u8) as i64, "C".into(),
-                < XC as borsh::BorshSchema > ::declaration()), (u8::from(3u8) as i64, "D"
-                .into(), < XD as borsh::BorshSchema > ::declaration()), (u8::from(4u8) as
-                i64, "E".into(), < XE as borsh::BorshSchema > ::declaration()),
-                (u8::from(5u8) as i64, "F".into(), < XF as borsh::BorshSchema >
-                ::declaration())
+                < ___XC as borsh::BorshSchema > ::declaration()), (u8::from(3u8) as i64,
+                "D".into(), < ___XD as borsh::BorshSchema > ::declaration()),
+                (u8::from(4u8) as i64, "E".into(), < ___XE as borsh::BorshSchema >
+                ::declaration()), (u8::from(5u8) as i64, "F".into(), < ___XF as
+                borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for X {
     fn declaration() -> borsh::schema::Declaration {
-        "X".to_string()
+        format!("{}::{}", std::module_path!(), "X")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -62,4 +62,3 @@ impl borsh::BorshSchema for X {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
@@ -15,44 +15,44 @@ impl borsh::BorshSchema for X {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XA;
+        struct ___XA;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XB;
+        struct ___XB;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XC;
+        struct ___XC;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XD;
+        struct ___XD;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XE;
+        struct ___XE;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct XF;
-        <XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        struct ___XF;
+        <___XA as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XC as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XD as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XE as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___XF as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0) as i64, "A".into(), < XA as borsh::BorshSchema >
-                ::declaration()), (u8::from(20) as i64, "B".into(), < XB as
+                (u8::from(0) as i64, "A".into(), < ___XA as borsh::BorshSchema >
+                ::declaration()), (u8::from(20) as i64, "B".into(), < ___XB as
                 borsh::BorshSchema > ::declaration()), (u8::from(20 + 1) as i64, "C"
-                .into(), < XC as borsh::BorshSchema > ::declaration()), (u8::from(20 + 1
-                + 1) as i64, "D".into(), < XD as borsh::BorshSchema > ::declaration()),
-                (u8::from(10) as i64, "E".into(), < XE as borsh::BorshSchema >
-                ::declaration()), (u8::from(10 + 1) as i64, "F".into(), < XF as
-                borsh::BorshSchema > ::declaration())
+                .into(), < ___XC as borsh::BorshSchema > ::declaration()), (u8::from(20 +
+                1 + 1) as i64, "D".into(), < ___XD as borsh::BorshSchema >
+                ::declaration()), (u8::from(10) as i64, "E".into(), < ___XE as
+                borsh::BorshSchema > ::declaration()), (u8::from(10 + 1) as i64, "F"
+                .into(), < ___XF as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -15,35 +15,35 @@ impl borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AEggs;
+        struct ___AEggs;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASalad(Tomatoes, Cucumber, Oil);
+        struct ___ASalad(Tomatoes, Cucumber, Oil);
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASausage {
+        struct ___ASausage {
             wrapper: Wrapper,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASalad as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASausage as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < AEggs as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < ___AEggs as
                 borsh::BorshSchema > ::declaration()), (u8::from(2u8) as i64, "Salad"
-                .into(), < ASalad as borsh::BorshSchema > ::declaration()),
-                (u8::from(3u8) as i64, "Sausage".into(), < ASausage as borsh::BorshSchema
-                > ::declaration())
+                .into(), < ___ASalad as borsh::BorshSchema > ::declaration()),
+                (u8::from(3u8) as i64, "Sausage".into(), < ___ASausage as
+                borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -53,4 +53,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -23,34 +23,34 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AEggs;
+        struct ___AEggs;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASalad<C>(Tomatoes, C, Oil);
+        struct ___ASalad<C>(Tomatoes, C, Oil);
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASausage<W> {
+        struct ___ASausage<W> {
             wrapper: W,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < AEggs as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < ___AEggs as
                 borsh::BorshSchema > ::declaration()), (u8::from(2u8) as i64, "Salad"
-                .into(), < ASalad < C > as borsh::BorshSchema > ::declaration()),
-                (u8::from(3u8) as i64, "Sausage".into(), < ASausage < W > as
+                .into(), < ___ASalad < C > as borsh::BorshSchema > ::declaration()),
+                (u8::from(3u8) as i64, "Sausage".into(), < ___ASausage < W > as
                 borsh::BorshSchema > ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -12,7 +12,7 @@ where
             < C as borsh::BorshSchema > ::declaration(), < W as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -61,4 +61,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -12,7 +12,7 @@ where
             < U as borsh::BorshSchema > ::declaration(), < C as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -63,4 +63,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -23,36 +23,39 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AEggs;
+        struct ___AEggs;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASalad<C>(Tomatoes, C, Oil);
+        struct ___ASalad<C>(Tomatoes, C, Oil);
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASausage<W, U> {
+        struct ___ASausage<W, U> {
             #[borsh(skip)]
             wrapper: W,
             filling: Filling,
             unexpected: U,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W, U> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASausage<
+            W,
+            U,
+        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < AEggs as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < ___AEggs as
                 borsh::BorshSchema > ::declaration()), (u8::from(2u8) as i64, "Salad"
-                .into(), < ASalad < C > as borsh::BorshSchema > ::declaration()),
-                (u8::from(3u8) as i64, "Sausage".into(), < ASausage < W, U > as
+                .into(), < ___ASalad < C > as borsh::BorshSchema > ::declaration()),
+                (u8::from(3u8) as i64, "Sausage".into(), < ___ASausage < W, U > as
                 borsh::BorshSchema > ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -11,7 +11,7 @@ where
         let params = borsh::__private::maybestd::vec![
             < W as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -63,4 +63,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -22,37 +22,37 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AEggs;
+        struct ___AEggs;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASalad<C: Eq>(Tomatoes, #[borsh(skip)] C, Oil);
+        struct ___ASalad<C: Eq>(Tomatoes, #[borsh(skip)] C, Oil);
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ASausage<W>
+        struct ___ASausage<W>
         where
             W: Hash,
         {
             wrapper: W,
             filling: Filling,
         }
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASalad<C> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ASausage<W> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < AEggs as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < ___AEggs as
                 borsh::BorshSchema > ::declaration()), (u8::from(2u8) as i64, "Salad"
-                .into(), < ASalad < C > as borsh::BorshSchema > ::declaration()),
-                (u8::from(3u8) as i64, "Sausage".into(), < ASausage < W > as
+                .into(), < ___ASalad < C > as borsh::BorshSchema > ::declaration()),
+                (u8::from(3u8) as i64, "Sausage".into(), < ___ASausage < W > as
                 borsh::BorshSchema > ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -44,4 +44,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -15,7 +15,7 @@ impl borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AB {
+        struct ___AB {
             c: i32,
             #[borsh(skip)]
             d: u32,
@@ -24,17 +24,17 @@ impl borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ANegative {
+        struct ___ANegative {
             beta: String,
         }
-        <AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AB as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___ANegative as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "B".into(), < AB as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Negative".into(), < ANegative
-                as borsh::BorshSchema > ::declaration())
+                (u8::from(0u8) as i64, "B".into(), < ___AB as borsh::BorshSchema >
+                ::declaration()), (u8::from(1u8) as i64, "Negative".into(), <
+                ___ANegative as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -19,7 +19,9 @@ where
             ::declaration(), < K::Associated as borsh::BorshSchema > ::declaration(), < V
             as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "EnumParametrized", params.join(", "))
+        format!(
+            r#"{}::{}<{}>"#, std::module_path!(), "EnumParametrized", params.join(", ")
+        )
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -71,4 +73,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -32,7 +32,7 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct EnumParametrizedB<K, V>
+        struct ___EnumParametrizedB<K, V>
         where
             K: TraitName,
             K: core::cmp::Ord,
@@ -45,25 +45,25 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct EnumParametrizedC<T>(
+        struct ___EnumParametrizedC<T>(
             T,
             u16,
         )
         where
             T: Eq + Hash;
-        <EnumParametrizedB<
+        <___EnumParametrizedB<
             K,
             V,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <EnumParametrizedC<
+        <___EnumParametrizedC<
             T,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "B".into(), < EnumParametrizedB < K, V > as
+                (u8::from(0u8) as i64, "B".into(), < ___EnumParametrizedB < K, V > as
                 borsh::BorshSchema > ::declaration()), (u8::from(1u8) as i64, "C".into(),
-                < EnumParametrizedC < T > as borsh::BorshSchema > ::declaration())
+                < ___EnumParametrizedC < T > as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -19,7 +19,9 @@ where
             ::declaration(), < < K as TraitName > ::Associated as borsh::BorshSchema >
             ::declaration(), < V as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "EnumParametrized", params.join(", "))
+        format!(
+            r#"{}::{}<{}>"#, std::module_path!(), "EnumParametrized", params.join(", ")
+        )
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -72,4 +74,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -32,7 +32,7 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct EnumParametrizedB<K, V>
+        struct ___EnumParametrizedB<K, V>
         where
             K: TraitName,
             K: core::cmp::Ord,
@@ -46,25 +46,25 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct EnumParametrizedC<T>(
+        struct ___EnumParametrizedC<T>(
             T,
             u16,
         )
         where
             T: Eq + Hash;
-        <EnumParametrizedB<
+        <___EnumParametrizedB<
             K,
             V,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <EnumParametrizedC<
+        <___EnumParametrizedC<
             T,
         > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "B".into(), < EnumParametrizedB < K, V > as
+                (u8::from(0u8) as i64, "B".into(), < ___EnumParametrizedB < K, V > as
                 borsh::BorshSchema > ::declaration()), (u8::from(1u8) as i64, "C".into(),
-                < EnumParametrizedC < T > as borsh::BorshSchema > ::declaration())
+                < ___EnumParametrizedC < T > as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -13,7 +13,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -52,4 +52,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -24,7 +24,7 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AB<K: Key, V>
+        struct ___AB<K: Key, V>
         where
             V: Value,
         {
@@ -34,14 +34,14 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AC<K: Key>(K, Vec<A>);
-        <AB<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AC<K> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        struct ___AC<K: Key>(K, Vec<A>);
+        <___AB<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AC<K> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "B".into(), < AB < K, V > as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "C".into(), < AC < K > as
+                (u8::from(0u8) as i64, "B".into(), < ___AB < K, V > as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "C".into(), < ___AC < K > as
                 borsh::BorshSchema > ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -15,18 +15,18 @@ impl borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct AEggs;
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        struct ___AEggs;
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___AEggs as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < AEggs as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration()), (u8::from(1u8) as i64, "Eggs".into(), < ___AEggs as
                 borsh::BorshSchema > ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -37,4 +37,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::BorshSchema for A {
     fn declaration() -> reexporter::borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut reexporter::borsh::__private::maybestd::collections::BTreeMap<
@@ -42,4 +42,3 @@ impl reexporter::borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -15,23 +15,23 @@ impl reexporter::borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(reexporter::borsh::BorshSchema)]
         #[borsh(crate = "reexporter :: borsh")]
-        struct ABacon;
+        struct ___ABacon;
         #[allow(dead_code)]
         #[derive(reexporter::borsh::BorshSchema)]
         #[borsh(crate = "reexporter :: borsh")]
-        struct AEggs;
-        <ABacon as reexporter::borsh::BorshSchema>::add_definitions_recursively(
+        struct ___AEggs;
+        <___ABacon as reexporter::borsh::BorshSchema>::add_definitions_recursively(
             definitions,
         );
-        <AEggs as reexporter::borsh::BorshSchema>::add_definitions_recursively(
+        <___AEggs as reexporter::borsh::BorshSchema>::add_definitions_recursively(
             definitions,
         );
         let definition = reexporter::borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: reexporter::borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as
                 reexporter::borsh::BorshSchema > ::declaration()), (u8::from(1u8) as i64,
-                "Eggs".into(), < AEggs as reexporter::borsh::BorshSchema >
+                "Eggs".into(), < ___AEggs as reexporter::borsh::BorshSchema >
                 ::declaration())
             ],
         };

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -15,13 +15,13 @@ impl borsh::BorshSchema for A {
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct ABacon;
-        <ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        struct ___ABacon;
+        <___ABacon as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Bacon".into(), < ABacon as borsh::BorshSchema >
-                ::declaration())
+                (u8::from(0u8) as i64, "Bacon".into(), < ___ABacon as borsh::BorshSchema
+                > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -31,4 +31,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -14,7 +14,7 @@ where
             < B as borsh::BorshSchema > ::declaration(), < A as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "Side", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "Side", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -55,4 +55,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -25,7 +25,7 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct SideLeft<A>(
+        struct ___SideLeft<A>(
             A,
         )
         where
@@ -33,19 +33,21 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct SideRight<B>(
+        struct ___SideRight<B>(
             B,
         )
         where
             B: Display + Debug;
-        <SideLeft<A> as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <SideRight<B> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___SideLeft<A> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___SideRight<
+            B,
+        > as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "Left".into(), < SideLeft < A > as
+                (u8::from(0u8) as i64, "Left".into(), < ___SideLeft < A > as
                 borsh::BorshSchema > ::declaration()), (u8::from(1u8) as i64, "Right"
-                .into(), < SideRight < B > as borsh::BorshSchema > ::declaration())
+                .into(), < ___SideRight < B > as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -12,7 +12,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "C", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "C", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -56,4 +56,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -23,11 +23,11 @@ where
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct CC3(u64, u64);
+        struct ___CC3(u64, u64);
         #[allow(dead_code)]
         #[derive(borsh::BorshSchema)]
         #[borsh(crate = "borsh")]
-        struct CC4<K, V>(
+        struct ___CC4<K, V>(
             u64,
             #[borsh(
                 schema(
@@ -39,14 +39,14 @@ where
             )]
             ThirdParty<K, V>,
         );
-        <CC3 as borsh::BorshSchema>::add_definitions_recursively(definitions);
-        <CC4<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___CC3 as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        <___CC4<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
         let definition = borsh::schema::Definition::Enum {
             tag_width: 1,
             variants: borsh::__private::maybestd::vec![
-                (u8::from(0u8) as i64, "C3".into(), < CC3 as borsh::BorshSchema >
-                ::declaration()), (u8::from(1u8) as i64, "C4".into(), < CC4 < K, V > as
-                borsh::BorshSchema > ::declaration())
+                (u8::from(0u8) as i64, "C3".into(), < ___CC3 as borsh::BorshSchema >
+                ::declaration()), (u8::from(1u8) as i64, "C4".into(), < ___CC4 < K, V >
+                as borsh::BorshSchema > ::declaration())
             ],
         };
         borsh::schema::add_definition(

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -49,12 +49,12 @@ fn declaration(ident_str: &str, cratename: Path, params_for_bounds: Vec<Type>) -
     }
     if declaration_params.is_empty() {
         quote! {
-                #ident_str.to_string()
+            format!("{}::{}", std::module_path!(), #ident_str)
         }
     } else {
         quote! {
                 let params = #cratename::__private::maybestd::vec![#(#declaration_params),*];
-                format!(r#"{}<{}>"#, #ident_str, params.join(", "))
+                format!(r#"{}::{}<{}>"#, std::module_path!(), #ident_str, params.join(", "))
         }
     }
 }

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
@@ -13,7 +13,7 @@ where
             < V as borsh::BorshSchema > ::declaration(), < T::Associated as
             borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "Parametrized", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -47,4 +47,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
@@ -13,7 +13,7 @@ where
             < V as borsh::BorshSchema > ::declaration(), < < T as TraitName >
             ::Associated as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "Parametrized", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -47,4 +47,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
@@ -15,7 +15,7 @@ where
             ::declaration(), < < T as TraitName > ::Associated as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "Parametrized", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "Parametrized", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -50,4 +50,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -10,7 +10,7 @@ where
         let params = borsh::__private::maybestd::vec![
             < U as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "G", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "G", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -39,4 +39,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -10,7 +10,7 @@ where
         let params = borsh::__private::maybestd::vec![
             < U as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "G", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "G", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -37,4 +37,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -12,7 +12,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "G", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "G", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -44,4 +44,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
@@ -12,7 +12,7 @@ where
             < U as borsh::BorshSchema > ::declaration(), < K as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "G", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "G", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -43,4 +43,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl<C> borsh::BorshSchema for ASalad<C> {
     fn declaration() -> borsh::schema::Declaration {
-        "ASalad".to_string()
+        format!("{}::{}", std::module_path!(), "ASalad")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -35,4 +35,3 @@ impl<C> borsh::BorshSchema for ASalad<C> {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for CRecC {
     fn declaration() -> borsh::schema::Declaration {
-        "CRecC".to_string()
+        format!("{}::{}", std::module_path!(), "CRecC")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -39,4 +39,3 @@ impl borsh::BorshSchema for CRecC {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
@@ -10,7 +10,7 @@ where
         let params = borsh::__private::maybestd::vec![
             < V as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -45,4 +45,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
@@ -12,7 +12,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -47,4 +47,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -35,4 +35,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl reexporter::borsh::BorshSchema for A {
     fn declaration() -> reexporter::borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut reexporter::borsh::__private::maybestd::collections::BTreeMap<
@@ -40,4 +40,3 @@ impl reexporter::borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
@@ -13,7 +13,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -48,4 +48,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -35,4 +35,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
@@ -12,7 +12,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -43,4 +43,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -33,4 +33,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -27,4 +27,3 @@ impl borsh::BorshSchema for A {
         if no_recursion_flag {}
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
@@ -4,7 +4,7 @@ expression: pretty_print_syn_str(&actual).unwrap()
 ---
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
-        "A".to_string()
+        format!("{}::{}", std::module_path!(), "A")
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -27,4 +27,3 @@ impl borsh::BorshSchema for A {
         if no_recursion_flag {}
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
@@ -12,7 +12,7 @@ where
             < K as borsh::BorshSchema > ::declaration(), < V as borsh::BorshSchema >
             ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -43,4 +43,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
@@ -10,7 +10,7 @@ where
         let params = borsh::__private::maybestd::vec![
             < T as borsh::BorshSchema > ::declaration()
         ];
-        format!(r#"{}<{}>"#, "A", params.join(", "))
+        format!(r#"{}::{}<{}>"#, std::module_path!(), "A", params.join(", "))
     }
     fn add_definitions_recursively(
         definitions: &mut borsh::__private::maybestd::collections::BTreeMap<
@@ -37,4 +37,3 @@ where
         }
     }
 }
-


### PR DESCRIPTION
this pr is copy of #300 
sketch of possible solution to #92, both the original issue and the widened perspective

this results in 
```rust
    #[derive(borsh::BorshSchema)]
    enum A {
        Bacon(Vec<i64>),
        Eggs,
    }
```
=> 
```bash
{
    "Vec<i64>": Sequence {
        length_width: 4,
        length_range: 0..=4294967295,
        elements: "i64",
    },
    "i64": Primitive(
        8,
    ),
    "tests::schema::test_simple_enums::A": Enum {
        tag_width: 1,
        variants: [
            (
                0,
                "Bacon",
                "tests::schema::test_simple_enums::___ABacon",
            ),
            (
                1,
                "Eggs",
                "tests::schema::test_simple_enums::___AEggs",
            ),
        ],
    },
    "tests::schema::test_simple_enums::___ABacon": Struct {
        fields: UnnamedFields(
            [
                "Vec<i64>",
            ],
        ),
    },
    "tests::schema::test_simple_enums::___AEggs": Struct {
        fields: Empty,
    },
}
```
---
this may have very weak interoperability with [borsh-js](https://github.com/near/borsh-js) due to being specific to rust
