### PR TITLE
chore: Add a feature gate to allow user disabling the NaN check

### DIFF
--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -73,8 +73,7 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh` in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
 ```bash
  1  error: proc-macro derive panicked
@@ -360,8 +359,7 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh` in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
 ```bash
  1  error: proc-macro derive panicked

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -694,8 +694,7 @@ Attribute takes literal string value, which is the syn's [Path] to `borsh` crate
 
 Attribute is optional.
 
-1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh`
-in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
+1. If the attribute is not provided, [crate_name](proc_macro_crate::crate_name) is used to find a version of `borsh` in `[dependencies]` of the relevant `Cargo.toml`. If there is no match, a compilation error, similar to the following, is raised:
 
 ```bash
  1  error: proc-macro derive panicked
@@ -821,8 +820,7 @@ Attribute takes literal string value, which is a comma-separated list of `Parame
 ###### usage
 It may be used in order to:
 
-1. fix complex cases, when derive hasn't figured out the right bounds on type parameters and
-declaration parameters automatically.
+1. fix complex cases, when derive hasn't figured out the right bounds on type parameters and declaration parameters automatically.
 2. remove parameters, which do not take part in serialization/deserialization, from bounded ones and from declaration parameters.
 
 `ParameterOverride` describes an entry like `order_param => override_type`,

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -54,3 +54,4 @@ std = []
 # Be sure that this is what you want before enabling this feature.
 rc = []
 de_strict_order = []
+allow_nan = []

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -282,6 +282,7 @@ macro_rules! impl_for_float {
                     .read_exact(&mut buf)
                     .map_err(unexpected_eof_to_unexpected_length_of_input)?;
                 let res = $type::from_bits($int_type::from_le_bytes(buf.try_into().unwrap()));
+                #[cfg(not(feature = "allow_nan"))]
                 if res.is_nan() {
                     return Err(Error::new(
                         ErrorKind::InvalidData,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -138,6 +138,7 @@ macro_rules! impl_for_float {
         impl BorshSerialize for $type {
             #[inline]
             fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+                #[cfg(not(feature = "allow_nan"))]
                 if self.is_nan() {
                     return Err(Error::new(ErrorKind::InvalidData, FLOAT_NAN_ERR));
                 }


### PR DESCRIPTION
In the current implementation, there is an enforced check for NaN values during the serialization and deserialization of f32 and f64 because of cross platform problems. However, if user operate within homogenous environments where cross-platform compatibility is not a concern they cannot disable the check.

This PR add a feature gate to make this possible.


 