### PR TITLE
feat: Add support for serde_json::Value

### DIFF
--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -46,7 +46,7 @@ features = ["derive", "unstable__schema", "rc"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["std", "json"]
+default = ["std"]
 derive = ["borsh-derive"]
 unstable__schema = ["derive", "borsh-derive/schema"]
 std = []

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -36,6 +36,7 @@ borsh-derive = { path = "../borsh-derive", version = "~1.5.1", optional = true }
 hashbrown = { version = ">=0.11,<0.15.0", optional = true }
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }
+serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 insta = "1.29.0"
@@ -45,7 +46,7 @@ features = ["derive", "unstable__schema", "rc"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["std"]
+default = ["std", "json"]
 derive = ["borsh-derive"]
 unstable__schema = ["derive", "borsh-derive/schema"]
 std = []
@@ -54,3 +55,5 @@ std = []
 # Be sure that this is what you want before enabling this feature.
 rc = []
 de_strict_order = []
+# Implements BorshSerialize and BorshDeserialize for serde_json::Value.
+json = ["serde_json"]

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -511,7 +511,7 @@ impl BorshDeserialize for serde_json::Number {
                 // This returns None if the number is a NaN or +/-Infinity,
                 // which are not valid JSON numbers.
                 Self::from_f64(f).ok_or_else(|| {
-                    let msg = format!("Invalid JSON number representation: {}", f);
+                    let msg = format!("Invalid JSON number: {}", f);
 
                     Error::new(ErrorKind::InvalidData, msg)
                 })

--- a/borsh/tests/roundtrip/test_json.rs
+++ b/borsh/tests/roundtrip/test_json.rs
@@ -1,0 +1,59 @@
+use serde_json::json;
+
+#[test]
+fn test_json_value() {
+    let original = json!({
+        "null": null,
+        "true": true,
+        "false": false,
+        "zero": 0,
+        "positive_integer": 12345,
+        "negative_integer": -88888,
+        "positive_float": 123.45,
+        "negative_float": -888.88,
+        "positive_max": 1.7976931348623157e+308,
+        "negative_max": -1.7976931348623157e+308,
+        "string": "Larry",
+        "array_of_nulls": [null, null, null],
+        "array_of_numbers": [0, -1, 1, 1.1, -1.1, 34798324],
+        "array_of_strings": ["Larry", "Jake", "Pumpkin"],
+        "array_of_arrays": [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9]
+        ],
+        "array_of_objects": [
+            {
+                "name": "Larry",
+                "age": 30
+            },
+            {
+                "name": "Jake",
+                "age": 7
+            },
+            {
+                "name": "Pumpkin",
+                "age": 8
+            }
+        ],
+        "object": {
+            "name": "Larry",
+            "age": 30,
+            "pets": [
+                {
+                    "name": "Jake",
+                    "age": 7
+                },
+                {
+                    "name": "Pumpkin",
+                    "age": 8
+                }
+            ]
+        }
+    });
+
+    let serialized = borsh::to_vec(&original).unwrap();
+    let deserialized: serde_json::Value = borsh::from_slice(&serialized).unwrap();
+
+    assert_eq!(original, deserialized);
+}

--- a/borsh/tests/tests.rs
+++ b/borsh/tests/tests.rs
@@ -50,6 +50,8 @@ mod roundtrip {
     mod test_cells;
     #[cfg(feature = "rc")]
     mod test_rc;
+    #[cfg(feature = "json")]
+    mod test_json;
 
     #[cfg(feature = "derive")]
     mod requires_derive_category {


### PR DESCRIPTION
Implement `BorshSerialize` and `BorshDeserialize` for `serde_json::Value`.

This is useful, for example, if a program is to take an arbitrary JSON as input (as `Value`), and store it as raw bytes.

We found that for this use case, borsh produces much more compact bytes, is faster, and results in smaller program size, compared to using JSON strings.

Thank you!