### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.1...borsh-v1.6.0) - 2024-11-07
+## [1.5.2](https://github.com/near/borsh-rs/compare/borsh-v1.5.1...borsh-v1.5.2) - 2024-11-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.1...borsh-v1.6.0) - 2024-11-07
+
+### Added
+
+- ser/de for `IpAddr` type; schema for `Ipv4Addr`/`Ipv6Addr`/`IpAddr` types  ([#309](https://github.com/near/borsh-rs/pull/309))
+
+### Other
+
+- `serde_json::Value` bridging example/doc ([#317](https://github.com/near/borsh-rs/pull/317))
+- remove dependency on syn_derive ([#318](https://github.com/near/borsh-rs/pull/318))
+- cover one more `syn::generics::TypeParamBound` as per syntax change ([#316](https://github.com/near/borsh-rs/pull/316))
+
 ## [1.5.1](https://github.com/near/borsh-rs/compare/borsh-v1.5.0...borsh-v1.5.1) - 2024-05-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.6.0"
+version = "1.5.2"
 rust-version = "1.67.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.5.1"
+version = "1.6.0"
 rust-version = "1.67.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.5.1", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.5.2", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.5.1 -> 1.5.2 (✓ API compatible changes)
* `borsh-derive`: 1.5.1 -> 1.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.5.2](https://github.com/near/borsh-rs/compare/borsh-v1.5.1...borsh-v1.5.2) - 2024-11-07

### Added

- ser/de for `IpAddr` type; schema for `Ipv4Addr`/`Ipv6Addr`/`IpAddr` types  ([#309](https://github.com/near/borsh-rs/pull/309))

### Other

- `serde_json::Value` bridging example/doc ([#317](https://github.com/near/borsh-rs/pull/317))
- remove dependency on syn_derive ([#318](https://github.com/near/borsh-rs/pull/318))
- cover one more `syn::generics::TypeParamBound` as per syntax change ([#316](https://github.com/near/borsh-rs/pull/316))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).