### PR TITLE
chore: cover one more `syn::generics::TypeParamBound` as per syntax change

### DIFF
--- a/borsh-derive/src/internals/generics.rs
+++ b/borsh-derive/src/internals/generics.rs
@@ -259,7 +259,9 @@ impl FindTyParams {
         )]
         match bound {
             TypeParamBound::Trait(bound) => self.visit_path(&bound.path),
-            TypeParamBound::Lifetime(_) | TypeParamBound::Verbatim(_) => {}
+            TypeParamBound::Lifetime(_)
+            | TypeParamBound::Verbatim(_)
+            | TypeParamBound::PreciseCapture(_) => {}
             _ => {}
         }
     }


### PR DESCRIPTION
this resolves ci failure https://github.com/near/borsh-rs/actions/runs/11550974184/job/32147032938 by mirroring change in https://github.com/serde-rs/serde/commit/8b0f482666c5deca3bdc440f6b1dcaf84d2d2a62