### PR TITLE
chore: remove dependency on syn_derive

### DIFF
--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -23,7 +23,6 @@ proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
 once_cell = "1.18.0"
-syn_derive = "0.1.6"
 
 [dev-dependencies]
 syn = { version = "2", features = ["full", "fold", "parsing"] }

--- a/borsh-derive/src/internals/attributes/field/schema.rs
+++ b/borsh-derive/src/internals/attributes/field/schema.rs
@@ -6,7 +6,12 @@ use crate::internals::attributes::{
     Symbol,
 };
 use once_cell::sync::Lazy;
-use syn::{meta::ParseNestedMeta, Ident, Token, Type};
+use quote::ToTokens;
+use syn::{
+    meta::ParseNestedMeta,
+    parse::{Parse, ParseStream},
+    Ident, Token, Type,
+};
 
 use self::with_funcs::{WithFuncs, WITH_FUNCS_FIELD_PARSE_MAP};
 
@@ -52,11 +57,29 @@ pub static SCHEMA_FIELD_PARSE_MAP: Lazy<BTreeMap<Symbol, Box<ParseFn>>> = Lazy::
 /**
 Struct describes an entry like `order_param => override_type`,  e.g. `K => <K as TraitName>::Associated`
 */
-#[derive(Clone, syn_derive::Parse, syn_derive::ToTokens)]
+#[derive(Clone)]
 pub struct ParameterOverride {
     pub order_param: Ident,
     arrow_token: Token![=>],
     pub override_type: Type,
+}
+
+impl Parse for ParameterOverride {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        Ok(ParameterOverride {
+            order_param: input.parse()?,
+            arrow_token: input.parse()?,
+            override_type: input.parse()?,
+        })
+    }
+}
+
+impl ToTokens for ParameterOverride {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.order_param.to_tokens(tokens);
+        self.arrow_token.to_tokens(tokens);
+        self.override_type.to_tokens(tokens);
+    }
 }
 
 #[allow(unused)]


### PR DESCRIPTION
Removes dependency on `syn_derive` crate. 

The added dependency is saving 21 lines of code at the cost of added Cargo.lock entries for a large list of projects depending on borsh-rs. The motivation came from the fact that `proc-macro-error` crate is unmaintained and the rust ecosystem is slowly transitioning into `proc-macro-error2` (already 800k downloads) but this change did not land on `syn_derive`. This causes crates depending on `borsh-rs` transtively depending on `syn_derive` and thus `proc-macro-error`.  Also it is generally thought as a good practice to remove external dependencies especially if they are not gaining us much to begin with.

Related to https://rustsec.org/advisories/RUSTSEC-2024-0370.html