### PR TITLE
fix: specify a minimum version for `syn` as `2.0.81`

### DIFF
--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -25,7 +25,7 @@ quote = "1"
 once_cell = "1.18.0"
 
 [dev-dependencies]
-syn = { version = "2", features = ["full", "fold", "parsing"] }
+syn = { version = "2.0.81", features = ["full", "fold", "parsing"] }
 prettyplease = "0.2.9"
 insta = "1.29.0"
 

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["*.snap"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "fold"] }
+syn = { version = "2.0.81", features = ["full", "fold"] }
 proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"


### PR DESCRIPTION
resolves https://github.com/near/borsh-rs/issues/319