### PR TITLE
chore: release v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.5](https://github.com/near/borsh-rs/compare/borsh-v1.5.4...borsh-v1.5.5) - 2025-01-18
+
+### Other
+
+- bump hashbrown to 0.15 (#333)
+- fix typo in private module name (#332)
+
 ## [1.5.4](https://github.com/near/borsh-rs/compare/borsh-v1.5.3...borsh-v1.5.4) - 2025-01-13
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.5.4"
+version = "1.5.5"
 rust-version = "1.67.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.5.4", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.5.5", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION
## 🤖 New release
* `borsh`: 1.5.4 -> 1.5.5 (✓ API compatible changes)
* `borsh-derive`: 1.5.4 -> 1.5.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `borsh`
<blockquote>

## [1.5.5](https://github.com/near/borsh-rs/compare/borsh-v1.5.4...borsh-v1.5.5) - 2025-01-18

### Other

- bump hashbrown to 0.15 (#333)
- fix typo in private module name (#332)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).