### PR TITLE
WIP: Add generic async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 [workspace.package]
 # shared version of all public crates in the workspace
 version = "1.5.4"
-rust-version = "1.67.0"
+edition = "2018"
+rust-version = "1.70.0"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,7 +3,7 @@ name = "benchmarks"
 version.workspace = true
 rust-version.workspace = true
 authors = ["Near Inc <hello@nearprotocol.com>"]
-edition = "2018"
+edition.workspace = true
 publish = false
 
 # This is somehow needed for command line arguments to work: https://github.com/bheisler/criterion.rs/issues/193#issuecomment-415740713

--- a/borsh-derive/Cargo.toml
+++ b/borsh-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "borsh-derive"
 version.workspace = true
 rust-version.workspace = true
 authors = ["Near Inc <hello@nearprotocol.com>"]
-edition = "2018"
+edition.workspace = true
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["encoding", "network-programming"]
@@ -18,14 +18,14 @@ exclude = ["*.snap"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.81", features = ["full", "fold"] }
+syn = { version = "2.0", features = ["full", "fold"] }
 proc-macro-crate = "3"
-proc-macro2 = "1"
-quote = "1"
+proc-macro2 = "1.0"
+quote = "1.0"
 once_cell = "1.18.0"
 
 [dev-dependencies]
-syn = { version = "2.0.81", features = ["full", "fold", "parsing"] }
+syn = { version = "2.0", features = ["parsing"] }
 prettyplease = "0.2.9"
 insta = "1.29.0"
 

--- a/borsh-derive/src/lib.rs
+++ b/borsh-derive/src/lib.rs
@@ -52,10 +52,7 @@ pub fn borsh_serialize(input: TokenStream) -> TokenStream {
         // Derive macros can only be defined on structs, enums, and unions.
         unreachable!()
     };
-    TokenStream::from(match res {
-        Ok(res) => res,
-        Err(err) => err.to_compile_error(),
-    })
+    TokenStream::from(res.unwrap_or_else(|err| err.to_compile_error()))
 }
 
 /// ---
@@ -80,10 +77,7 @@ pub fn borsh_deserialize(input: TokenStream) -> TokenStream {
         // Derive macros can only be defined on structs, enums, and unions.
         unreachable!()
     };
-    TokenStream::from(match res {
-        Ok(res) => res,
-        Err(err) => err.to_compile_error(),
-    })
+    TokenStream::from(res.unwrap_or_else(|err| err.to_compile_error()))
 }
 
 /// ---
@@ -104,7 +98,7 @@ pub fn borsh_schema(input: TokenStream) -> TokenStream {
     } else if let Ok(input) = syn::parse::<ItemEnum>(input.clone()) {
         schema::enums::process(&input, cratename)
     } else if syn::parse::<ItemUnion>(input).is_ok() {
-        Err(syn::Error::new(
+        Err(Error::new(
             Span::call_site(),
             "Borsh schema does not support unions yet.",
         ))
@@ -112,8 +106,5 @@ pub fn borsh_schema(input: TokenStream) -> TokenStream {
         // Derive macros can only be defined on structs, enums, and unions.
         unreachable!()
     };
-    TokenStream::from(match res {
-        Ok(res) => res,
-        Err(err) => err.to_compile_error(),
-    })
+    TokenStream::from(res.unwrap_or_else(|err| err.to_compile_error()))
 }

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -43,8 +43,8 @@ bson = { version = "2", optional = true }
 
 async-generic = { git = "https://github.com/DanikVitek/async-generic.git", version = "2.0" }
 async-trait = { version = "0.1", optional = true }
-tokio = { version = "1", features = ["io-util"], optional = true }
-async-std = { version = "1", features = ["async-io"], optional = true }
+tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
+async-std = { version = "1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 insta = "1.29.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -3,7 +3,7 @@ name = "borsh"
 version.workspace = true
 rust-version.workspace = true
 authors = ["Near Inc <hello@near.org>"]
-edition = "2018"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 categories = ["encoding", "network-programming"]
@@ -41,6 +41,11 @@ hashbrown = { version = ">=0.11,<0.15.0", optional = true }
 bytes = { version = "1", optional = true }
 bson = { version = "2", optional = true }
 
+async-generic = { git = "https://github.com/DanikVitek/async-generic.git", version = "2.0" }
+async-trait = { version = "0.1", optional = true }
+tokio = { version = "1", features = ["io-util"], optional = true }
+async-std = { version = "1", features = ["async-io"], optional = true }
+
 [dev-dependencies]
 insta = "1.29.0"
 serde_json = { version = "1" }
@@ -52,6 +57,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 default = ["std"]
 derive = ["borsh-derive"]
+async = ["dep:async-trait"]
+tokio = ["async", "dep:tokio"]
+async-std = ["async", "dep:async-std"]
 unstable__schema = ["derive", "borsh-derive/schema"]
 std = []
 # Opt into impls for Rc<T> and Arc<T>. Serializing and deserializing these types

--- a/borsh/src/async_io.rs
+++ b/borsh/src/async_io.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AsyncRead: Unpin + Send {
+    async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>;
+
+    async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()>;
+}
+
+#[cfg(feature = "tokio")]
+#[async_trait]
+impl<R: tokio::io::AsyncReadExt + Unpin + Send> AsyncRead for R {
+    #[inline]
+    async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        tokio::io::AsyncReadExt::read(self, buf).await
+    }
+
+    #[inline]
+    async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        tokio::io::AsyncReadExt::read_exact(self, buf)
+            .await
+            .map(|_| ())
+    }
+}
+
+#[cfg(feature = "async-std")]
+#[async_trait]
+impl<R: async_std::io::ReadExt + Unpin + Send> AsyncRead for R {
+    #[inline]
+    async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        async_std::io::ReadExt::read(self, buf).await
+    }
+
+    #[inline]
+    async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        async_std::io::ReadExt::read_exact(self, buf).await
+    }
+}
+
+#[async_trait]
+pub trait AsyncWrite: Unpin + Send {
+    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()>;
+}
+
+#[cfg(feature = "tokio")]
+#[async_trait]
+impl<R: tokio::io::AsyncWriteExt + Unpin + Send> AsyncWrite for R {
+    #[inline]
+    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        tokio::io::AsyncWriteExt::write_all(self, buf).await
+    }
+}
+
+#[cfg(feature = "async-std")]
+#[async_trait]
+impl<R: async_std::io::WriteExt + Unpin + Send> AsyncWrite for R {
+    #[inline]
+    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        async_std::io::WriteExt::write_all(self, buf).await
+    }
+}

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -49,7 +49,6 @@ pub trait BorshDeserialize: Sized {
     }
 
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self>;
@@ -65,7 +64,6 @@ pub trait BorshDeserialize: Sized {
     }
 
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn try_from_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -86,7 +84,6 @@ pub trait BorshDeserialize: Sized {
     #[inline]
     #[doc(hidden)]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(len: u32, reader: &mut R) -> Result<Option<Vec<Self>>>
     )]
     fn vec_from_reader<R: Read>(len: u32, reader: &mut R) -> Result<Option<Vec<Self>>> {
@@ -98,7 +95,6 @@ pub trait BorshDeserialize: Sized {
     #[inline]
     #[doc(hidden)]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead, const N: usize>(reader: &mut R) -> Result<Option<[Self; N]>>
     )]
     fn array_from_reader<R: Read, const N: usize>(reader: &mut R) -> Result<Option<[Self; N]>> {
@@ -206,7 +202,6 @@ pub trait EnumExt: BorshDeserialize {
     /// assert!(from_slice::<OneOrZero>(&data[..]).is_err());
     /// ```
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R, tag: u8) -> Result<Self>
     )]
     fn deserialize_variant<R: Read>(reader: &mut R, tag: u8) -> Result<Self>;
@@ -228,7 +223,6 @@ fn unexpected_eof_to_unexpected_length_of_input(e: Error) -> Error {
 impl BorshDeserialize for u8 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -242,7 +236,6 @@ impl BorshDeserialize for u8 {
     #[inline]
     #[doc(hidden)]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(len: u32, reader: &mut R) -> Result<Option<Vec<Self>>>
     )]
     fn vec_from_reader<R: Read>(len: u32, reader: &mut R) -> Result<Option<Vec<Self>>> {
@@ -279,7 +272,6 @@ impl BorshDeserialize for u8 {
     #[inline]
     #[doc(hidden)]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead, const N: usize>(reader: &mut R) -> Result<Option<[Self; N]>>
     )]
     fn array_from_reader<R: Read, const N: usize>(reader: &mut R) -> Result<Option<[Self; N]>> {
@@ -294,16 +286,15 @@ impl BorshDeserialize for u8 {
 macro_rules! impl_for_integer {
     ($type: ident) => {
         #[async_generic(
-                            #[cfg(feature = "async")]
-                            #[cfg_attr(feature = "async", async_trait)]
-                            async_trait
-                        )]
+            #[cfg(feature = "async")]
+            #[cfg_attr(feature = "async", async_trait)]
+            async_trait
+        )]
         impl BorshDeserialize for $type {
             #[inline]
             #[async_generic(
-                                #[cfg(feature = "async")]
-                                async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
-                            )]
+                async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
+            )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
                 let mut buf = [0u8; size_of::<$type>()];
                 let res = reader.read_exact(&mut buf);
@@ -336,7 +327,6 @@ macro_rules! impl_for_nonzero_integer {
         impl BorshDeserialize for $type {
             #[inline]
             #[async_generic(
-                #[cfg(feature = "async")]
                 async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -372,7 +362,6 @@ macro_rules! impl_for_size_integer {
         )]
         impl BorshDeserialize for $type {
             #[async_generic(
-                #[cfg(feature = "async")]
                 async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -404,7 +393,6 @@ macro_rules! impl_for_float {
         impl BorshDeserialize for $type {
             #[inline]
             #[async_generic(
-                #[cfg(feature = "async")]
                 async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -436,7 +424,6 @@ impl_for_float!(f64, u64);
 impl BorshDeserialize for bool {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -470,7 +457,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -513,7 +499,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -553,7 +538,6 @@ where
 impl BorshDeserialize for String {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -596,7 +580,6 @@ pub mod ascii {
     impl BorshDeserialize for ascii::AsciiString {
         #[inline]
         #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -618,7 +601,6 @@ pub mod ascii {
     impl BorshDeserialize for ascii::AsciiChar {
         #[inline]
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -646,7 +628,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -689,7 +670,6 @@ where
 impl BorshDeserialize for bytes::Bytes {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -711,7 +691,6 @@ impl BorshDeserialize for bytes::Bytes {
 impl BorshDeserialize for BytesMut {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -741,7 +720,6 @@ impl BorshDeserialize for BytesMut {
 impl BorshDeserialize for bson::oid::ObjectId {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -770,7 +748,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -795,7 +772,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -821,7 +797,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -878,7 +853,6 @@ pub mod hashes {
     {
         #[inline]
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -929,7 +903,6 @@ pub mod hashes {
     {
         #[inline]
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -978,7 +951,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1028,7 +1000,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1074,7 +1045,6 @@ where
 impl BorshDeserialize for std::net::SocketAddr {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1113,7 +1083,6 @@ impl BorshDeserialize for std::net::SocketAddr {
 impl BorshDeserialize for std::net::IpAddr {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1158,7 +1127,6 @@ impl BorshDeserialize for std::net::IpAddr {
 impl BorshDeserialize for std::net::SocketAddrV4 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1185,7 +1153,6 @@ impl BorshDeserialize for std::net::SocketAddrV4 {
 impl BorshDeserialize for std::net::SocketAddrV6 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1212,7 +1179,6 @@ impl BorshDeserialize for std::net::SocketAddrV6 {
 impl BorshDeserialize for std::net::Ipv4Addr {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1233,7 +1199,6 @@ impl BorshDeserialize for std::net::Ipv4Addr {
 impl BorshDeserialize for std::net::Ipv6Addr {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1262,7 +1227,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1415,7 +1379,6 @@ fn array_deserialization_doesnt_leak() {
     )]
     impl BorshDeserialize for MyType {
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1467,7 +1430,6 @@ macro_rules! impl_tuple {
         impl BorshDeserialize for $name {
             #[inline]
             #[async_generic(
-                #[cfg(feature = "async")]
                 async_signature<R: AsyncRead>(_reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(_reader: &mut R) -> Result<Self> {
@@ -1490,7 +1452,6 @@ macro_rules! impl_tuple {
         {
             #[inline]
             #[async_generic(
-                #[cfg(feature = "async")]
                 async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1537,8 +1498,7 @@ macro_rules! impl_range {
         )]
         impl<T: BorshDeserialize> BorshDeserialize for core::ops::$type<T> {
             #[inline]
-                    #[async_generic(
-                #[cfg(feature = "async")]
+            #[async_generic(
                 async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
             )]
             fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1596,7 +1556,6 @@ pub mod rc {
     {
         #[inline]
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1627,7 +1586,6 @@ pub mod rc {
     {
         #[inline]
         #[async_generic(
-            #[cfg(feature = "async")]
             async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
         )]
         fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1649,7 +1607,6 @@ pub mod rc {
 impl<T: ?Sized> BorshDeserialize for PhantomData<T> {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(_: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(_: &mut R) -> Result<Self> {
@@ -1670,7 +1627,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -1696,7 +1652,6 @@ where
 {
     #[inline]
     #[async_generic(
-        #[cfg(feature = "async")]
         async_signature<R: AsyncRead>(reader: &mut R) -> Result<Self>
     )]
     fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -41,6 +41,9 @@ pub mod error;
 #[cfg(all(feature = "std", feature = "hashbrown"))]
 compile_error!("feature \"std\" and feature \"hashbrown\" don't make sense at the same time");
 
+#[cfg(all(feature = "tokio", feature = "async-std"))]
+compile_error!("Cannot enable both `async-tokio` and `async-std` features at the same time");
+
 #[cfg(feature = "std")]
 use std::io as io_impl;
 #[cfg(not(feature = "std"))]

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -48,6 +48,9 @@ compile_error!("Cannot enable both `async-tokio` and `async-std` features at the
 use std::io as io_impl;
 #[cfg(not(feature = "std"))]
 mod nostd_io;
+#[cfg(feature = "async")]
+pub mod async_io;
+
 #[cfg(not(feature = "std"))]
 use nostd_io as io_impl;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2018"
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"


### PR DESCRIPTION
The conversation started in #150.
`async-generic` PR: https://github.com/scouten/async-generic/pull/17

This implementation should be more flexible, as it allows for different runtimes and provides traits for manual implementation in case of any uncommon runtime.