### PR TITLE
fix(derive): require `Default` trait bound for the skipped field type, rather than for its type parameters

### DIFF
--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -469,7 +469,6 @@ mod tests_schema {
         },
     };
 
-    use quote::quote;
     use syn::{parse_quote, Attribute, ItemStruct};
 
     use super::schema;

--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -165,8 +165,7 @@ impl Attributes {
         Ok(result)
     }
     pub(crate) fn needs_bounds_derive(&self, ty: BoundType) -> bool {
-        let predicates = self.get_bounds(ty);
-        predicates.is_none()
+        self.get_bounds(ty).is_none()
     }
 
     fn get_bounds(&self, ty: BoundType) -> Option<Vec<WherePredicate>> {
@@ -243,8 +242,7 @@ impl Attributes {
 
 #[cfg(test)]
 mod tests {
-    use quote::quote;
-    use syn::{Attribute, ItemStruct};
+    use syn::{parse_quote, Attribute, ItemStruct};
 
     fn parse_bounds(attrs: &[Attribute]) -> Result<Option<bounds::Bounds>, syn::Error> {
         // #[borsh(bound(serialize = "...", deserialize = "..."))]
@@ -261,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_reject_multiple_borsh_attrs() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(skip)]
                 #[borsh(bound(deserialize = "K: Hash + Ord,
@@ -272,8 +270,7 @@ mod tests {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match Attributes::parse(&first_field.attrs) {
@@ -285,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing1() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K: Hash + Ord,
                      V: Eq + Ord",
@@ -295,8 +292,7 @@ mod tests {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = parse_bounds(&first_field.attrs).unwrap().unwrap();
@@ -306,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K: Hash + Eq + borsh::de::BorshDeserialize,
                      V: borsh::de::BorshDeserialize",
@@ -316,8 +312,7 @@ mod tests {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = parse_bounds(&first_field.attrs).unwrap().unwrap();
@@ -327,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing3() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K: Hash + Eq + borsh::de::BorshDeserialize,
                      V: borsh::de::BorshDeserialize",
@@ -336,8 +331,7 @@ mod tests {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = parse_bounds(&first_field.attrs).unwrap().unwrap();
@@ -347,14 +341,13 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing4() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K: Hash"))]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = parse_bounds(&first_field.attrs).unwrap().unwrap();
@@ -364,14 +357,13 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing_error() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deser = "K: Hash"))]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match parse_bounds(&first_field.attrs) {
@@ -383,14 +375,13 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing_error2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K Hash"))]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match parse_bounds(&first_field.attrs) {
@@ -402,14 +393,13 @@ mod tests {
 
     #[test]
     fn test_bounds_parsing_error3() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = 42))]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match parse_bounds(&first_field.attrs) {
@@ -421,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_ser_de_with_parsing1() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(
                     serialize_with = "third_party_impl::serialize_third_party",
@@ -430,8 +420,7 @@ mod tests {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = Attributes::parse(&first_field.attrs).unwrap();
@@ -440,14 +429,13 @@ mod tests {
     }
     #[test]
     fn test_borsh_skip() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(skip)]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
 
@@ -456,13 +444,12 @@ mod tests {
     }
     #[test]
     fn test_borsh_no_skip() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
 
@@ -483,7 +470,7 @@ mod tests_schema {
     };
 
     use quote::quote;
-    use syn::{Attribute, ItemStruct};
+    use syn::{parse_quote, Attribute, ItemStruct};
 
     use super::schema;
     fn parse_schema_attrs(attrs: &[Attribute]) -> Result<Option<schema::Attributes>, syn::Error> {
@@ -494,7 +481,7 @@ mod tests_schema {
 
     #[test]
     fn test_root_bounds_and_params_combined() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(
                     serialize_with = "third_party_impl::serialize_third_party",
@@ -504,8 +491,7 @@ mod tests_schema {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
 
@@ -521,7 +507,7 @@ mod tests_schema {
 
     #[test]
     fn test_schema_params_parsing1() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -532,8 +518,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let schema_attrs = parse_schema_attrs(&first_field.attrs).unwrap();
@@ -541,7 +526,7 @@ mod tests_schema {
     }
     #[test]
     fn test_schema_params_parsing_error() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -552,8 +537,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match parse_schema_attrs(&first_field.attrs) {
@@ -565,7 +549,7 @@ mod tests_schema {
 
     #[test]
     fn test_schema_params_parsing_error2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -576,8 +560,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match parse_schema_attrs(&first_field.attrs) {
@@ -589,7 +572,7 @@ mod tests_schema {
 
     #[test]
     fn test_schema_params_parsing2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -600,8 +583,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let schema_attrs = parse_schema_attrs(&first_field.attrs).unwrap();
@@ -609,7 +591,7 @@ mod tests_schema {
     }
     #[test]
     fn test_schema_params_parsing3() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -618,8 +600,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let schema_attrs = parse_schema_attrs(&first_field.attrs).unwrap();
@@ -628,7 +609,7 @@ mod tests_schema {
 
     #[test]
     fn test_schema_params_parsing4() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -636,8 +617,7 @@ mod tests_schema {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let schema_attrs = parse_schema_attrs(&first_field.attrs).unwrap();
@@ -646,7 +626,7 @@ mod tests_schema {
 
     #[test]
     fn test_schema_with_funcs_parsing() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(schema(with_funcs(
                     declaration = "third_party_impl::declaration::<K, V>",
@@ -655,8 +635,7 @@ mod tests_schema {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = Attributes::parse(&first_field.attrs).unwrap();
@@ -670,7 +649,7 @@ mod tests_schema {
     // both `declaration` and `definitions` have to be specified
     #[test]
     fn test_schema_with_funcs_parsing_error() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(schema(with_funcs(
                     declaration = "third_party_impl::declaration::<K, V>"
@@ -678,8 +657,7 @@ mod tests_schema {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let attrs = Attributes::parse(&first_field.attrs);
@@ -693,14 +671,13 @@ mod tests_schema {
 
     #[test]
     fn test_root_error() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(boons)]
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
         let err = match Attributes::parse(&first_field.attrs) {
@@ -712,7 +689,7 @@ mod tests_schema {
 
     #[test]
     fn test_root_bounds_and_wrong_key_combined() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 #[borsh(bound(deserialize = "K: Hash"),
                         schhema(params = "T => <T as TraitName>::Associated, V => Vec<V>")
@@ -720,8 +697,7 @@ mod tests_schema {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
 

--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -185,37 +185,41 @@ impl Attributes {
 #[cfg(feature = "schema")]
 impl Attributes {
     fn check_schema(&self, attr: &Attribute) -> Result<(), syn::Error> {
-        if let Some(ref schema) = self.schema {
-            if self.skip && schema.params.is_some() {
-                return Err(syn::Error::new_spanned(
-                    attr,
-                    format!(
-                        "`{}` cannot be used at the same time as `{}({})`",
-                        SKIP.0, SCHEMA.0, PARAMS.1
-                    ),
-                ));
-            }
+        let Some(ref schema) = self.schema else {
+            return Ok(());
+        };
 
-            if self.skip && schema.with_funcs.is_some() {
-                return Err(syn::Error::new_spanned(
-                    attr,
-                    format!(
-                        "`{}` cannot be used at the same time as `{}({})`",
-                        SKIP.0, SCHEMA.0, WITH_FUNCS.1
-                    ),
-                ));
-            }
+        if self.skip && schema.params.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!(
+                    "`{}` cannot be used at the same time as `{}({})`",
+                    SKIP.0, SCHEMA.0, PARAMS.1
+                ),
+            ));
         }
+
+        if self.skip && schema.with_funcs.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!(
+                    "`{}` cannot be used at the same time as `{}({})`",
+                    SKIP.0, SCHEMA.0, WITH_FUNCS.1
+                ),
+            ));
+        }
+
         Ok(())
     }
 
     pub(crate) fn needs_schema_params_derive(&self) -> bool {
-        if let Some(ref schema) = self.schema {
-            if schema.params.is_some() {
-                return false;
-            }
-        }
-        true
+        !matches!(
+            &self.schema,
+            Some(schema::Attributes {
+                params: Some(_),
+                ..
+            })
+        )
     }
 
     pub(crate) fn schema_declaration(&self) -> Option<syn::ExprPath> {

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
@@ -15,7 +15,7 @@ impl borsh::de::EnumExt for X {
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             X::A
         } else if variant_tag == 1u8 {
             X::B
@@ -28,7 +28,7 @@ impl borsh::de::EnumExt for X {
         } else if variant_tag == 5u8 {
             X::F
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -37,6 +37,6 @@ impl borsh::de::EnumExt for X {
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
@@ -15,7 +15,7 @@ impl borsh::de::EnumExt for X {
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0 {
+        let return_value = if variant_tag == 0 {
             X::A
         } else if variant_tag == 20 {
             X::B
@@ -28,7 +28,7 @@ impl borsh::de::EnumExt for X {
         } else if variant_tag == 10 + 1 {
             X::F
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -37,6 +37,6 @@ impl borsh::de::EnumExt for X {
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
@@ -28,7 +28,7 @@ impl borsh::de::EnumExt for A {
         } else if variant_tag == 5u8 {
             A::F
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -38,6 +38,6 @@ impl borsh::de::EnumExt for A {
             )
         };
         return_value.initialization_method();
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -2,7 +2,10 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
-impl borsh::de::BorshDeserialize for AA {
+impl borsh::de::BorshDeserialize for AA
+where
+    i32: ::core::default::Default,
+{
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
@@ -10,22 +13,25 @@ impl borsh::de::BorshDeserialize for AA {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
-impl borsh::de::EnumExt for AA {
+impl borsh::de::EnumExt for AA
+where
+    i32: ::core::default::Default,
+{
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             AA::B {
-                c: core::default::Default::default(),
-                d: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                c: ::core::default::Default::default(),
+                d: <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             AA::NegatedVariant {
-                beta: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                beta: <u8 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -34,6 +40,6 @@ impl borsh::de::EnumExt for AA {
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -2,7 +2,10 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
-impl borsh::de::BorshDeserialize for AAT {
+impl borsh::de::BorshDeserialize for AAT
+where
+    i32: ::core::default::Default,
+{
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
@@ -10,22 +13,25 @@ impl borsh::de::BorshDeserialize for AAT {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
-impl borsh::de::EnumExt for AAT {
+impl borsh::de::EnumExt for AAT
+where
+    i32: ::core::default::Default,
+{
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             AAT::B(
-                core::default::Default::default(),
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                ::core::default::Default::default(),
+                <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else if variant_tag == 1u8 {
             AAT::NegatedVariant {
-                beta: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                beta: <u8 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -34,6 +40,6 @@ impl borsh::de::EnumExt for AAT {
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
@@ -27,18 +27,21 @@ where
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-                y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <HashMap<
+                    K,
+                    V,
+                > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <K as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <Vec<U> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -47,6 +50,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
@@ -23,18 +23,18 @@ where
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             C::C3(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else if variant_tag == 1u8 {
             C::C4 {
-                x: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
                 y: third_party_impl::deserialize_third_party(reader)?,
             }
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -43,6 +43,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -7,8 +7,7 @@ where
     V: Value,
     K: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
-    K: core::default::Default,
-    V: core::default::Default,
+    HashMap<K, V>: ::core::default::Default,
 {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -22,25 +21,24 @@ where
     V: Value,
     K: borsh::de::BorshDeserialize,
     U: borsh::de::BorshDeserialize,
-    K: core::default::Default,
-    V: core::default::Default,
+    HashMap<K, V>: ::core::default::Default,
 {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: core::default::Default::default(),
-                y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: ::core::default::Default::default(),
+                y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <K as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <Vec<U> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -49,6 +47,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -7,7 +7,7 @@ where
     V: Value,
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
-    U: core::default::Default,
+    Vec<U>: ::core::default::Default,
 {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -21,24 +21,27 @@ where
     V: Value,
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
-    U: core::default::Default,
+    Vec<U>: ::core::default::Default,
 {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-                y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <HashMap<
+                    K,
+                    V,
+                > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                core::default::Default::default(),
+                <K as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                ::core::default::Default::default(),
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -47,6 +50,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
@@ -23,18 +23,21 @@ where
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::C {
-                a: borsh::BorshDeserialize::deserialize_reader(reader)?,
-                b: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                a: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                b: <HashMap<
+                    T,
+                    U,
+                > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::D(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -43,6 +46,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
@@ -25,18 +25,21 @@ where
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-                y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <HashMap<
+                    K,
+                    V,
+                > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <K as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <Vec<A> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -45,6 +48,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -17,18 +17,25 @@ impl reexporter::borsh::de::EnumExt for A {
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, reexporter::borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
-                y: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <HashMap<
+                    u32,
+                    String,
+                > as reexporter::borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                y: <String as reexporter::borsh::BorshDeserialize>::deserialize_reader(
+                    reader,
+                )?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
-                reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <K as reexporter::borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <Vec<
+                    u64,
+                > as reexporter::borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 reexporter::borsh::io::Error::new(
                     reexporter::borsh::io::ErrorKind::InvalidData,
                     reexporter::borsh::__private::maybestd::format!(
@@ -37,6 +44,6 @@ impl reexporter::borsh::de::EnumExt for A {
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
@@ -25,18 +25,21 @@ where
         reader: &mut __R,
         variant_tag: u8,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        let mut return_value = if variant_tag == 0u8 {
+        let return_value = if variant_tag == 0u8 {
             A::B {
-                x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-                y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                x: <HashMap<
+                    K,
+                    V,
+                > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             }
         } else if variant_tag == 1u8 {
             A::C(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <K as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <Vec<U> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             )
         } else {
-            return Err(
+            return ::core::result::Result::Err(
                 borsh::io::Error::new(
                     borsh::io::ErrorKind::InvalidData,
                     borsh::__private::maybestd::format!(
@@ -45,6 +48,6 @@ where
                 ),
             )
         };
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
@@ -7,10 +7,10 @@ impl borsh::de::BorshDeserialize for A {
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
         let mut return_value = Self {
-            x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+            x: <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         };
         return_value.initialization_method();
-        Ok(return_value)
+        ::core::result::Result::Ok(return_value)
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
@@ -11,9 +11,9 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            x: <HashMap<K, V> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
@@ -10,9 +10,9 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
+        ::core::result::Result::Ok(Self {
             x: third_party_impl::deserialize_third_party(reader)?,
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+            y: <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
@@ -10,9 +10,9 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            a: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            b: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            a: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            b: <HashMap<T, U> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -5,15 +5,14 @@ expression: pretty_print_syn_str(&actual).unwrap()
 impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     U: borsh::de::BorshDeserialize,
-    K: core::default::Default,
-    V: core::default::Default,
+    HashMap<K, V>: ::core::default::Default,
 {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            x: core::default::Default::default(),
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            x: ::core::default::Default::default(),
+            y: <U as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -5,16 +5,15 @@ expression: pretty_print_syn_str(&actual).unwrap()
 impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     U: borsh::de::BorshDeserialize,
-    K: core::default::Default,
-    V: core::default::Default,
+    HashMap<K, V>: ::core::default::Default,
 {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(
+        ::core::result::Result::Ok(
             Self(
-                core::default::Default::default(),
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                ::core::default::Default::default(),
+                <U as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             ),
         )
     }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -6,15 +6,15 @@ impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     K: borsh::de::BorshDeserialize,
     V: borsh::de::BorshDeserialize,
-    U: core::default::Default,
+    U: ::core::default::Default,
 {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(
+        ::core::result::Result::Ok(
             Self(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                core::default::Default::default(),
+                <HashMap<K, V> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                ::core::default::Default::default(),
             ),
         )
     }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
@@ -9,10 +9,10 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(
+        ::core::result::Result::Ok(
             Self(
-                core::default::Default::default(),
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                ::core::default::Default::default(),
+                <U as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             ),
         )
     }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
@@ -6,9 +6,12 @@ impl borsh::de::BorshDeserialize for CRecC {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            a: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            b: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            a: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            b: <HashMap<
+                String,
+                CRecC,
+            > as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -9,10 +9,10 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(
+        ::core::result::Result::Ok(
             Self(
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
-                borsh::BorshDeserialize::deserialize_reader(reader)?,
+                <T as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
             ),
         )
     }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
@@ -10,9 +10,9 @@ where
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            x: <HashMap<K, V> as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
@@ -6,9 +6,9 @@ impl borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, borsh::io::Error> {
-        Ok(Self {
-            x: borsh::BorshDeserialize::deserialize_reader(reader)?,
-            y: borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            x: <u64 as borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            y: <String as borsh::BorshDeserialize>::deserialize_reader(reader)?,
         })
     }
 }

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -6,9 +6,11 @@ impl reexporter::borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: reexporter::borsh::io::Read>(
         reader: &mut __R,
     ) -> ::core::result::Result<Self, reexporter::borsh::io::Error> {
-        Ok(Self {
-            x: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
-            y: reexporter::borsh::BorshDeserialize::deserialize_reader(reader)?,
+        ::core::result::Result::Ok(Self {
+            x: <u64 as reexporter::borsh::BorshDeserialize>::deserialize_reader(reader)?,
+            y: <String as reexporter::borsh::BorshDeserialize>::deserialize_reader(
+                reader,
+            )?,
         })
     }
 }

--- a/borsh-derive/src/internals/generics.rs
+++ b/borsh-derive/src/internals/generics.rs
@@ -166,6 +166,7 @@ impl FindTyParams {
 }
 
 impl FindTyParams {
+    /// Visits the filed to collect its type parameters
     pub fn visit_field(&mut self, field: &Field) {
         self.visit_type_top_level(&field.ty);
     }

--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -185,18 +185,18 @@ mod tests {
         default_cratename, local_insta_assert_debug_snapshot, local_insta_assert_snapshot,
         pretty_print_syn_str,
     };
+    use syn::parse_quote;
 
     use super::*;
 
     #[test]
     fn simple_enum() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A {
                 Bacon,
                 Eggs
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
 
@@ -205,15 +205,14 @@ mod tests {
 
     #[test]
     fn simple_enum_with_custom_crate() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A {
                 Bacon,
                 Eggs
             }
-        })
-        .unwrap();
+        };
 
-        let crate_: Path = syn::parse2(quote! { reexporter::borsh }).unwrap();
+        let crate_: Path = parse_quote! { reexporter::borsh };
         let actual = process(&item_enum, crate_).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -221,7 +220,7 @@ mod tests {
 
     #[test]
     fn borsh_discriminant_false() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
            #[borsh(use_discriminant = false)]
             enum X {
                 A,
@@ -231,15 +230,14 @@ mod tests {
                 E = 10,
                 F,
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
     #[test]
     fn borsh_discriminant_true() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             #[borsh(use_discriminant = true)]
             enum X {
                 A,
@@ -249,8 +247,7 @@ mod tests {
                 E = 10,
                 F,
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -258,12 +255,11 @@ mod tests {
 
     #[test]
     fn single_field_enum() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A {
                 Bacon,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -271,15 +267,14 @@ mod tests {
 
     #[test]
     fn complex_enum() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A {
                 Bacon,
                 Eggs,
                 Salad(Tomatoes, Cucumber, Oil),
                 Sausage{wrapper: Wrapper, filling: Filling},
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -287,15 +282,14 @@ mod tests {
 
     #[test]
     fn complex_enum_generics() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<C, W> {
                 Bacon,
                 Eggs,
                 Salad(Tomatoes, C, Oil),
                 Sausage{wrapper: W, filling: Filling},
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -303,7 +297,7 @@ mod tests {
 
     #[test]
     fn trailing_comma_generics() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum Side<B, A>
             where
                 A: Display + Debug,
@@ -312,16 +306,15 @@ mod tests {
                 Left(A),
                 Right(B),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn test_filter_foreign_attrs() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A {
                 #[serde(rename = "ab")]
                 B {
@@ -335,25 +328,23 @@ mod tests {
                     beta: String,
                 }
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn complex_enum_generics_borsh_skip_tuple_field() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<C: Eq, W> where W: Hash {
                 Bacon,
                 Eggs,
                 Salad(Tomatoes, #[borsh(skip)] C, Oil),
                 Sausage{wrapper: W, filling: Filling},
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -361,7 +352,7 @@ mod tests {
 
     #[test]
     fn complex_enum_generics_borsh_skip_named_field() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<W, U, C> {
                 Bacon,
                 Eggs,
@@ -373,8 +364,7 @@ mod tests {
                     unexpected: U,
                 },
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -382,7 +372,7 @@ mod tests {
 
     #[test]
     fn recursive_enum() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K: Key, V> where V: Value {
                 B {
                     x: HashMap<K, V>,
@@ -390,17 +380,16 @@ mod tests {
                 },
                 C(K, Vec<A>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn generic_associated_type() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum EnumParametrized<T, K, V>
             where
                 K: TraitName,
@@ -415,16 +404,16 @@ mod tests {
                 },
                 C(T, u16),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
+
     #[test]
     fn generic_associated_type_param_override() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum EnumParametrized<T, K, V>
             where
                 K: TraitName,
@@ -440,17 +429,16 @@ mod tests {
                 },
                 C(T, u16),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn generic_associated_type_param_override_conflict() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum EnumParametrized<T, K, V>
             where
                 K: TraitName,
@@ -462,17 +450,16 @@ mod tests {
                 },
                 C(T, u16),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename());
+        let actual = process(&item_enum, default_cratename());
 
         local_insta_assert_debug_snapshot!(actual.unwrap_err());
     }
 
     #[test]
     fn check_with_funcs_skip_conflict() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum C<K, V> {
                 C3(u64, u64),
                 C4(
@@ -484,17 +471,16 @@ mod tests {
                     ThirdParty<K, V>,
                 ),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename());
+        let actual = process(&item_enum, default_cratename());
 
         local_insta_assert_debug_snapshot!(actual.unwrap_err());
     }
 
     #[test]
     fn with_funcs_attr() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum C<K, V> {
                 C3(u64, u64),
                 C4(
@@ -506,10 +492,9 @@ mod tests {
                     ThirdParty<K, V>,
                 ),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{
-    punctuated::Punctuated, token::Comma, Field, Fields, GenericParam, Generics, Ident, Path, Type,
-    WherePredicate,
-};
+use syn::{parse_quote, punctuated::Punctuated, token::Comma, Field, Fields, GenericParam, Generics, Ident, Path, Type, WherePredicate};
 
 use crate::internals::{attributes::field, generics};
 
@@ -23,7 +20,7 @@ impl GenericsOutput {
         }
     }
     fn result(self, item_name: &str, cratename: &Path) -> (Vec<WherePredicate>, TokenStream2) {
-        let trait_path: Path = syn::parse2(quote! { #cratename::BorshSchema }).unwrap();
+        let trait_path: Path = parse_quote! { #cratename::BorshSchema };
         let predicates = generics::compute_predicates(
             self.params_visitor.clone().process_for_bounds(),
             &trait_path,

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -2,7 +2,10 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_quote, punctuated::Punctuated, token::Comma, Field, Fields, GenericParam, Generics, Ident, Path, Type, WherePredicate};
+use syn::{
+    parse_quote, punctuated::Punctuated, token::Comma, Field, Fields, GenericParam, Generics,
+    Ident, Path, Type, WherePredicate,
+};
 
 use crate::internals::{attributes::field, generics};
 

--- a/borsh-derive/src/internals/schema/structs/mod.rs
+++ b/borsh-derive/src/internals/schema/structs/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
-use syn::{ExprPath, Fields, Ident, ItemStruct, Path, Type};
+use syn::{parse_quote, ExprPath, Fields, Ident, ItemStruct, Path, Type};
 
 use crate::internals::{attributes::field, generics, schema};
 
@@ -14,7 +14,7 @@ fn field_declaration_output(
     declaration_override: Option<ExprPath>,
 ) -> TokenStream2 {
     let default_path: ExprPath =
-        syn::parse2(quote! { <#field_type as #cratename::BorshSchema>::declaration }).unwrap();
+        parse_quote! { <#field_type as #cratename::BorshSchema>::declaration };
 
     let path = declaration_override.unwrap_or(default_path);
 
@@ -171,10 +171,9 @@ mod tests {
 
     #[test]
     fn unit_struct() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A;
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -182,10 +181,9 @@ mod tests {
 
     #[test]
     fn wrapper_struct() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<T>(T);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -193,10 +191,9 @@ mod tests {
 
     #[test]
     fn tuple_struct() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A(u64, String);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -204,10 +201,9 @@ mod tests {
 
     #[test]
     fn tuple_struct_params() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K, V>(K, V);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -215,13 +211,12 @@ mod tests {
 
     #[test]
     fn simple_struct() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -229,28 +224,26 @@ mod tests {
 
     #[test]
     fn simple_struct_with_custom_crate() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A {
                 x: u64,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
-        let crate_: Path = syn::parse2(quote! { reexporter::borsh }).unwrap();
+        let crate_: Path = parse_quote! { reexporter::borsh };
         let actual = process(&item_struct, crate_).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn simple_generics() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K, V> {
                 x: HashMap<K, V>,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -258,7 +251,7 @@ mod tests {
 
     #[test]
     fn trailing_comma_generics() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K, V>
             where
                 K: Display + Debug,
@@ -266,8 +259,7 @@ mod tests {
                 x: HashMap<K, V>,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -275,10 +267,9 @@ mod tests {
 
     #[test]
     fn tuple_struct_whole_skip() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A(#[borsh(skip)] String);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -286,10 +277,9 @@ mod tests {
 
     #[test]
     fn tuple_struct_partial_skip() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A(#[borsh(skip)] u64, String);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -297,14 +287,13 @@ mod tests {
 
     #[test]
     fn generic_tuple_struct_borsh_skip1() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct G<K, V, U> (
                 #[borsh(skip)]
                 HashMap<K, V>,
                 U,
             );
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -313,14 +302,13 @@ mod tests {
 
     #[test]
     fn generic_tuple_struct_borsh_skip2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct G<K, V, U> (
                 HashMap<K, V>,
                 #[borsh(skip)]
                 U,
             );
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -329,15 +317,14 @@ mod tests {
 
     #[test]
     fn generic_tuple_struct_borsh_skip3() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct G<U, K, V> (
                 #[borsh(skip)]
                 HashMap<K, V>,
                 U,
                 K,
             );
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -346,10 +333,9 @@ mod tests {
 
     #[test]
     fn generic_tuple_struct_borsh_skip4() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct ASalad<C>(Tomatoes, #[borsh(skip)] C, Oil);
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -358,14 +344,13 @@ mod tests {
 
     #[test]
     fn generic_named_fields_struct_borsh_skip() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct G<K, V, U> {
                 #[borsh(skip)]
                 x: HashMap<K, V>,
                 y: U,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -374,13 +359,12 @@ mod tests {
 
     #[test]
     fn recursive_struct() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct CRecC {
                 a: String,
                 b: HashMap<String, CRecC>,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -389,7 +373,7 @@ mod tests {
 
     #[test]
     fn generic_associated_type() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T: Debug>
             where
                 T: TraitName,
@@ -397,8 +381,7 @@ mod tests {
                 field: T::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -407,7 +390,7 @@ mod tests {
 
     #[test]
     fn generic_associated_type_param_override() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -418,8 +401,7 @@ mod tests {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -428,7 +410,7 @@ mod tests {
 
     #[test]
     fn generic_associated_type_param_override2() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -439,8 +421,7 @@ mod tests {
                 field: (<T as TraitName>::Associated, T),
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -449,7 +430,7 @@ mod tests {
 
     #[test]
     fn generic_associated_type_param_override_conflict() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct Parametrized<V, T>
             where
                 T: TraitName,
@@ -460,8 +441,7 @@ mod tests {
                 field: <T as TraitName>::Associated,
                 another: V,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename());
 
@@ -470,7 +450,7 @@ mod tests {
 
     #[test]
     fn check_with_funcs_skip_conflict() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K, V> {
                 #[borsh(skip,schema(with_funcs(
                     declaration = "third_party_impl::declaration::<K, V>",
@@ -479,8 +459,7 @@ mod tests {
                 x: ThirdParty<K, V>,
                 y: u64,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename());
 
@@ -489,7 +468,7 @@ mod tests {
 
     #[test]
     fn with_funcs_attr() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K, V> {
                 #[borsh(schema(with_funcs(
                     declaration = "third_party_impl::declaration::<K, V>",
@@ -498,8 +477,7 @@ mod tests {
                 x: ThirdParty<K, V>,
                 y: u64,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 
@@ -508,7 +486,7 @@ mod tests {
 
     #[test]
     fn schema_param_override3() {
-        let item_struct: ItemStruct = syn::parse2(quote! {
+        let item_struct: ItemStruct = parse_quote! {
             struct A<K: EntityRef, V> {
                 #[borsh(
                     schema(
@@ -518,8 +496,7 @@ mod tests {
                 x: PrimaryMap<K, V>,
                 y: String,
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_struct, default_cratename()).unwrap();
 

--- a/borsh-derive/src/internals/serialize/enums/mod.rs
+++ b/borsh-derive/src/internals/serialize/enums/mod.rs
@@ -52,7 +52,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
                 writer.write_all(&variant_idx.to_le_bytes())?;
 
                 #fields_body
-                Ok(())
+                ::core::result::Result::Ok(())
             }
         }
     })
@@ -202,11 +202,12 @@ mod tests {
     use crate::internals::test_helpers::{
         default_cratename, local_insta_assert_snapshot, pretty_print_syn_str,
     };
+    use syn::parse_quote;
 
     use super::*;
     #[test]
     fn borsh_skip_tuple_variant_field() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum AATTB {
                 B(#[borsh(skip)] i32, #[borsh(skip)] u32),
 
@@ -214,8 +215,7 @@ mod tests {
                     beta: u8,
                 }
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn struct_variant_field() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum AB {
                 B {
                     c: i32,
@@ -234,8 +234,7 @@ mod tests {
                     beta: String,
                 }
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
 
@@ -244,7 +243,7 @@ mod tests {
 
     #[test]
     fn simple_enum_with_custom_crate() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum AB {
                 B {
                     c: i32,
@@ -255,10 +254,9 @@ mod tests {
                     beta: String,
                 }
             }
-        })
-        .unwrap();
+        };
 
-        let crate_: Path = syn::parse2(quote! { reexporter::borsh }).unwrap();
+        let crate_: Path = parse_quote! { reexporter::borsh };
         let actual = process(&item_enum, crate_).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -266,7 +264,7 @@ mod tests {
 
     #[test]
     fn borsh_skip_struct_variant_field() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
 
             enum AB {
                 B {
@@ -280,8 +278,7 @@ mod tests {
                     beta: String,
                 }
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
 
@@ -290,7 +287,7 @@ mod tests {
 
     #[test]
     fn borsh_skip_struct_variant_all_fields() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
 
             enum AAB {
                 B {
@@ -305,8 +302,7 @@ mod tests {
                     beta: String,
                 }
             }
-        })
-        .unwrap();
+        };
 
         let actual = process(&item_enum, default_cratename()).unwrap();
 
@@ -315,7 +311,7 @@ mod tests {
 
     #[test]
     fn simple_generics() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K, V, U> {
                 B {
                     x: HashMap<K, V>,
@@ -323,16 +319,15 @@ mod tests {
                 },
                 C(K, Vec<U>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn bound_generics() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K: Key, V, U> where V: Value {
                 B {
                     x: HashMap<K, V>,
@@ -340,16 +335,15 @@ mod tests {
                 },
                 C(K, Vec<U>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn recursive_enum() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K: Key, V> where V: Value {
                 B {
                     x: HashMap<K, V>,
@@ -357,17 +351,16 @@ mod tests {
                 },
                 C(K, Vec<A>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn generic_borsh_skip_struct_field() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K: Key, V, U> where V: Value {
                 B {
                     #[borsh(skip)]
@@ -376,17 +369,16 @@ mod tests {
                 },
                 C(K, Vec<U>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn generic_borsh_skip_tuple_field() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<K: Key, V, U> where V: Value {
                 B {
                     x: HashMap<K, V>,
@@ -394,17 +386,16 @@ mod tests {
                 },
                 C(K, #[borsh(skip)] Vec<U>),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn generic_serialize_bound() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum A<T: Debug, U> {
                 C {
                     a: String,
@@ -416,17 +407,16 @@ mod tests {
                 },
                 D(u32, u32),
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn check_serialize_with_attr() {
-        let item_struct: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum C<K: Ord, V> {
                 C3(u64, u64),
                 C4 {
@@ -435,17 +425,16 @@ mod tests {
                     y: ThirdParty<K, V>
                 },
             }
-        })
-        .unwrap();
+        };
 
-        let actual = process(&item_struct, default_cratename()).unwrap();
+        let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
 
     #[test]
     fn borsh_discriminant_false() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
            #[borsh(use_discriminant = false)]
             enum X {
                 A,
@@ -455,15 +444,15 @@ mod tests {
                 E = 10,
                 F,
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
     }
+
     #[test]
     fn borsh_discriminant_true() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             #[borsh(use_discriminant = true)]
             enum X {
                 A,
@@ -473,8 +462,7 @@ mod tests {
                 E = 10,
                 F,
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());
@@ -482,15 +470,14 @@ mod tests {
 
     #[test]
     fn mixed_with_unit_variants() {
-        let item_enum: ItemEnum = syn::parse2(quote! {
+        let item_enum: ItemEnum = parse_quote! {
             enum X {
                 A(u16),
                 B,
                 C {x: i32, y: i32},
                 D,
             }
-        })
-        .unwrap();
+        };
         let actual = process(&item_enum, default_cratename()).unwrap();
 
         local_insta_assert_snapshot!(pretty_print_syn_str(&actual).unwrap());

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
@@ -16,6 +16,6 @@ impl borsh::ser::BorshSerialize for X {
             X::F => 5u8,
         };
         writer.write_all(&variant_idx.to_le_bytes())?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
@@ -16,6 +16,6 @@ impl borsh::ser::BorshSerialize for X {
             X::F => 10 + 1,
         };
         writer.write_all(&variant_idx.to_le_bytes())?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
@@ -18,6 +18,6 @@ impl borsh::ser::BorshSerialize for AAB {
                 borsh::BorshSerialize::serialize(beta, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -20,6 +20,6 @@ impl borsh::ser::BorshSerialize for AB {
                 borsh::BorshSerialize::serialize(beta, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -18,6 +18,6 @@ impl borsh::ser::BorshSerialize for AATTB {
                 borsh::BorshSerialize::serialize(beta, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
@@ -28,6 +28,6 @@ where
                 borsh::BorshSerialize::serialize(id1, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
@@ -26,6 +26,6 @@ where
                 third_party_impl::serialize_third_party(y, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -26,6 +26,6 @@ where
                 borsh::BorshSerialize::serialize(id1, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -26,6 +26,6 @@ where
                 borsh::BorshSerialize::serialize(id0, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
@@ -26,6 +26,6 @@ where
                 borsh::BorshSerialize::serialize(id1, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/mixed_with_unit_variants.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/mixed_with_unit_variants.snap
@@ -24,6 +24,6 @@ impl borsh::ser::BorshSerialize for X {
             }
             _ => {}
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
@@ -27,6 +27,6 @@ where
                 borsh::BorshSerialize::serialize(id1, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -21,6 +21,6 @@ impl reexporter::borsh::ser::BorshSerialize for AB {
                 reexporter::borsh::BorshSerialize::serialize(beta, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
@@ -27,6 +27,6 @@ where
                 borsh::BorshSerialize::serialize(id1, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
@@ -21,6 +21,6 @@ impl borsh::ser::BorshSerialize for AB {
                 borsh::BorshSerialize::serialize(beta, writer)?;
             }
         }
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/mod.rs
+++ b/borsh-derive/src/internals/serialize/mod.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use std::convert::TryFrom;
-use syn::{Expr, ExprPath, Generics, Ident, Index, Path};
+use syn::{parse_quote, Expr, ExprPath, Generics, Ident, Index, Path};
 
 use super::generics;
 
@@ -22,7 +22,7 @@ impl GenericsOutput {
         }
     }
     fn extend(self, where_clause: &mut syn::WhereClause, cratename: &Path) {
-        let trait_path: Path = syn::parse2(quote! { #cratename::ser::BorshSerialize }).unwrap();
+        let trait_path: Path = parse_quote! { #cratename::ser::BorshSerialize };
         let predicates =
             generics::compute_predicates(self.serialize_visitor.process_for_bounds(), &trait_path);
         where_clause.predicates.extend(predicates);
@@ -65,12 +65,12 @@ impl FieldId {
 impl FieldId {
     fn serialize_arg(&self) -> Expr {
         match self {
-            Self::Struct(name) => syn::parse2(quote! { &self.#name }).unwrap(),
-            Self::StructUnnamed(index) => syn::parse2(quote! { &self.#index }).unwrap(),
-            Self::Enum(name) => syn::parse2(quote! { #name }).unwrap(),
+            Self::Struct(name) => parse_quote! { &self.#name },
+            Self::StructUnnamed(index) => parse_quote! { &self.#index },
+            Self::Enum(name) => parse_quote! { #name },
             Self::EnumUnnamed(ind) => {
                 let field = Ident::new(&format!("id{}", ind.index), Span::mixed_site());
-                syn::parse2(quote! { #field }).unwrap()
+                parse_quote! { #field }
             }
         }
     }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
@@ -14,6 +14,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
@@ -13,6 +13,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         third_party_impl::serialize_third_party(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
@@ -14,6 +14,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.field, writer)?;
         borsh::BorshSerialize::serialize(&self.another, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -11,6 +11,6 @@ where
         writer: &mut __W,
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
@@ -13,6 +13,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.a, writer)?;
         borsh::BorshSerialize::serialize(&self.b, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -11,6 +11,6 @@ where
         writer: &mut __W,
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.1, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -12,6 +12,6 @@ where
         writer: &mut __W,
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.0, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
@@ -14,6 +14,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.field, writer)?;
         borsh::BorshSerialize::serialize(&self.another, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
@@ -9,6 +9,6 @@ impl borsh::ser::BorshSerialize for CRecC {
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.a, writer)?;
         borsh::BorshSerialize::serialize(&self.b, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -12,6 +12,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.0, writer)?;
         borsh::BorshSerialize::serialize(&self.1, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
@@ -13,6 +13,6 @@ where
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
@@ -9,6 +9,6 @@ impl borsh::ser::BorshSerialize for A {
     ) -> ::core::result::Result<(), borsh::io::Error> {
         borsh::BorshSerialize::serialize(&self.x, writer)?;
         borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -9,6 +9,6 @@ impl reexporter::borsh::ser::BorshSerialize for A {
     ) -> ::core::result::Result<(), reexporter::borsh::io::Error> {
         reexporter::borsh::BorshSerialize::serialize(&self.x, writer)?;
         reexporter::borsh::BorshSerialize::serialize(&self.y, writer)?;
-        Ok(())
+        ::core::result::Result::Ok(())
     }
 }

--- a/borsh/tests/compile_derives/test_generic_structs.rs
+++ b/borsh/tests/compile_derives/test_generic_structs.rs
@@ -66,7 +66,7 @@ struct G1<K, V, U>(#[borsh(skip)] HashMap<K, V>, U);
 struct G2<K: Ord + Hash + Eq, R, U>(HashMap<K, R>, #[borsh(skip)] U);
 
 /// implicit derived `core::default::Default` bounds on `K` and `V` are dropped by empty bound
-/// specified, as `HashMap` hash its own `Default` implementation
+/// specified, as `HashMap` has its own `Default` implementation
 #[cfg(hash_collections)]
 #[derive(BorshDeserialize)]
 struct G3<K, V, U>(#[borsh(skip, bound(deserialize = ""))] HashMap<K, V>, U);

--- a/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
+++ b/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
@@ -15,6 +15,7 @@ enum B {
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 struct C {
     x: u64,
+    #[allow(unused)]
     #[borsh(skip)]
     y: String,
 }

--- a/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
+++ b/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
@@ -17,5 +17,5 @@ struct C {
     x: u64,
     #[allow(unused)]
     #[borsh(skip)]
-    y: String,
+    y: u64,
 }

--- a/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
+++ b/borsh/tests/compile_derives/test_macro_namespace_collisions.rs
@@ -11,3 +11,10 @@ enum B {
     C,
     D,
 }
+
+#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
+struct C {
+    x: u64,
+    #[borsh(skip)]
+    y: String,
+}


### PR DESCRIPTION
Fixes #339