### PR TITLE
chore: add automatically_derived attribute to derive macros

### DIFF
--- a/borsh-derive/src/internals/deserialize/enums/mod.rs
+++ b/borsh-derive/src/internals/deserialize/enums/mod.rs
@@ -33,6 +33,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
     generics_output.extend(&mut where_clause, &cratename);
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
             fn deserialize_reader<__R: #cratename::io::Read>(reader: &mut __R) -> ::core::result::Result<Self, #cratename::io::Error> {
                 let tag = <u8 as #cratename::de::BorshDeserialize>::deserialize_reader(reader)?;
@@ -40,6 +41,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
             }
         }
 
+        #[automatically_derived]
         impl #impl_generics #cratename::de::EnumExt for #name #ty_generics #where_clause {
             fn deserialize_variant<__R: #cratename::io::Read>(
                 reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_false.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for X {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -10,6 +11,7 @@ impl borsh::de::BorshDeserialize for X {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl borsh::de::EnumExt for X {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_discriminant_true.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for X {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -10,6 +11,7 @@ impl borsh::de::BorshDeserialize for X {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl borsh::de::EnumExt for X {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_init_func.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -10,6 +11,7 @@ impl borsh::de::BorshDeserialize for A {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl borsh::de::EnumExt for A {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for AA {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -10,6 +11,7 @@ impl borsh::de::BorshDeserialize for AA {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl borsh::de::EnumExt for AA {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for AAT {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,
@@ -10,6 +11,7 @@ impl borsh::de::BorshDeserialize for AAT {
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl borsh::de::EnumExt for AAT {
     fn deserialize_variant<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/bound_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::BorshDeserialize for A<K, V, U>
 where
     V: Value,
@@ -16,6 +17,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::EnumExt for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/check_deserialize_with_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Ord, V> borsh::de::BorshDeserialize for C<K, V>
 where
     K: borsh::de::BorshDeserialize,
@@ -14,6 +15,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K: Ord, V> borsh::de::EnumExt for C<K, V>
 where
     K: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::BorshDeserialize for A<K, V, U>
 where
     V: Value,
@@ -17,6 +18,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::EnumExt for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::BorshDeserialize for A<K, V, U>
 where
     V: Value,
@@ -16,6 +17,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K: Key, V, U> borsh::de::EnumExt for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/generic_deserialize_bound.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T: Debug, U> borsh::de::BorshDeserialize for A<T, U>
 where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,
@@ -14,6 +15,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<T: Debug, U> borsh::de::EnumExt for A<T, U>
 where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/recursive_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V> borsh::de::BorshDeserialize for A<K, V>
 where
     V: Value,
@@ -15,6 +16,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K: Key, V> borsh::de::EnumExt for A<K, V>
 where
     V: Value,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: reexporter::borsh::io::Read>(
         reader: &mut __R,
@@ -12,6 +13,7 @@ impl reexporter::borsh::de::BorshDeserialize for A {
         <Self as reexporter::borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl reexporter::borsh::de::EnumExt for A {
     fn deserialize_variant<__R: reexporter::borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/enums/snapshots/simple_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::de::BorshDeserialize for A<K, V, U>
 where
     K: borsh::de::BorshDeserialize,
@@ -15,6 +16,7 @@ where
         <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
     }
 }
+#[automatically_derived]
 impl<K, V, U> borsh::de::EnumExt for A<K, V, U>
 where
     K: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/mod.rs
+++ b/borsh-derive/src/internals/deserialize/structs/mod.rs
@@ -39,6 +39,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
 
     if let Some(method_ident) = item::contains_initialize_with(&input.attrs)? {
         Ok(quote! {
+            #[automatically_derived]
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
                 fn deserialize_reader<__R: #cratename::io::Read>(reader: &mut __R) -> ::core::result::Result<Self, #cratename::io::Error> {
                     let mut return_value = #return_value;
@@ -49,6 +50,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
         })
     } else {
         Ok(quote! {
+            #[automatically_derived]
             impl #impl_generics #cratename::de::BorshDeserialize for #name #ty_generics #where_clause {
                 fn deserialize_reader<__R: #cratename::io::Read>(reader: &mut __R) -> ::core::result::Result<Self, #cratename::io::Error> {
                     Ok(#return_value)

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/borsh_init_func.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/bound_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V> borsh::de::BorshDeserialize for A<K, V>
 where
     V: Value,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/check_deserialize_with_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Ord, V> borsh::de::BorshDeserialize for A<K, V>
 where
     K: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_deserialize_bound.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T: Debug, U> borsh::de::BorshDeserialize for C<T, U>
 where
     T: PartialOrd + Hash + Eq + borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     U: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     U: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::de::BorshDeserialize for G<K, V, U>
 where
     K: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/override_automatically_added_default_trait.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::de::BorshDeserialize for G1<K, V, U>
 where
     U: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/recursive_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for CRecC {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T> borsh::de::BorshDeserialize for TupleA<T>
 where
     T: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::de::BorshDeserialize for A<K, V>
 where
     K: borsh::de::BorshDeserialize,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/deserialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/deserialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::de::BorshDeserialize for A {
     fn deserialize_reader<__R: reexporter::borsh::io::Read>(
         reader: &mut __R,

--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -76,6 +76,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
     let (predicates, declaration) = generics_output.result(&enum_name, &cratename);
     where_clause.predicates.extend(predicates);
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #cratename::BorshSchema for #name #ty_generics #where_clause {
             fn declaration() -> #cratename::schema::Declaration {
                 #declaration

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_false.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for X {
     fn declaration() -> borsh::schema::Declaration {
         "X".to_string()
@@ -62,4 +63,3 @@ impl borsh::BorshSchema for X {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/borsh_discriminant_true.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for X {
     fn declaration() -> borsh::schema::Declaration {
         "X".to_string()
@@ -62,4 +63,3 @@ impl borsh::BorshSchema for X {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -53,4 +54,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<C, W> borsh::BorshSchema for A<C, W>
 where
     C: borsh::BorshSchema,
@@ -61,4 +62,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_named_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<W, U, C> borsh::BorshSchema for A<W, U, C>
 where
     U: borsh::BorshSchema,
@@ -63,4 +64,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/complex_enum_generics_borsh_skip_tuple_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<C: Eq, W> borsh::BorshSchema for A<C, W>
 where
     W: Hash,
@@ -63,4 +64,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/filter_foreign_attrs.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -44,4 +45,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T, K, V> borsh::BorshSchema for EnumParametrized<T, K, V>
 where
     K: TraitName,
@@ -71,4 +72,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/generic_associated_type_param_override.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T, K, V> borsh::BorshSchema for EnumParametrized<T, K, V>
 where
     K: TraitName,
@@ -72,4 +73,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/recursive_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V> borsh::BorshSchema for A<K, V>
 where
     V: Value,
@@ -52,4 +53,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -37,4 +38,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::BorshSchema for A {
     fn declaration() -> reexporter::borsh::schema::Declaration {
         "A".to_string()
@@ -42,4 +43,3 @@ impl reexporter::borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/single_field_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -31,4 +32,3 @@ impl borsh::BorshSchema for A {
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/trailing_comma_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<B, A> borsh::BorshSchema for Side<B, A>
 where
     A: Display + Debug,
@@ -55,4 +56,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/enums/snapshots/with_funcs_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::BorshSchema for C<K, V>
 where
     K: borsh::BorshSchema,
@@ -56,4 +57,3 @@ where
         );
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/mod.rs
+++ b/borsh-derive/src/internals/schema/structs/mod.rs
@@ -74,6 +74,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
     let (predicates, declaration) = generics_output.result(&struct_name, &cratename);
     where_clause.predicates.extend(predicates);
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #cratename::BorshSchema for #name #ty_generics #where_clause {
             fn declaration() -> #cratename::schema::Declaration {
                 #declaration

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<V, T: Debug> borsh::BorshSchema for Parametrized<V, T>
 where
     T: TraitName,
@@ -47,4 +48,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<V, T> borsh::BorshSchema for Parametrized<V, T>
 where
     T: TraitName,
@@ -47,4 +48,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_associated_type_param_override2.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<V, T> borsh::BorshSchema for Parametrized<V, T>
 where
     T: TraitName,
@@ -50,4 +51,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::BorshSchema for G<K, V, U>
 where
     U: borsh::BorshSchema,
@@ -39,4 +40,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::BorshSchema for G<K, V, U>
 where
     U: borsh::BorshSchema,
@@ -37,4 +38,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::BorshSchema for G<K, V, U>
 where
     K: borsh::BorshSchema,
@@ -44,4 +45,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip3.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<U, K, V> borsh::BorshSchema for G<U, K, V>
 where
     U: borsh::BorshSchema,
@@ -43,4 +44,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/generic_tuple_struct_borsh_skip4.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<C> borsh::BorshSchema for ASalad<C> {
     fn declaration() -> borsh::schema::Declaration {
         "ASalad".to_string()
@@ -35,4 +36,3 @@ impl<C> borsh::BorshSchema for ASalad<C> {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/recursive_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for CRecC {
     fn declaration() -> borsh::schema::Declaration {
         "CRecC".to_string()
@@ -39,4 +40,3 @@ impl borsh::BorshSchema for CRecC {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/schema_param_override3.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: EntityRef, V> borsh::BorshSchema for A<K, V>
 where
     V: borsh::BorshSchema,
@@ -45,4 +46,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::BorshSchema for A<K, V>
 where
     K: borsh::BorshSchema,
@@ -47,4 +48,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -35,4 +36,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::BorshSchema for A {
     fn declaration() -> reexporter::borsh::schema::Declaration {
         "A".to_string()
@@ -40,4 +41,3 @@ impl reexporter::borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/trailing_comma_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::BorshSchema for A<K, V>
 where
     K: Display + Debug,
@@ -48,4 +49,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -35,4 +36,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_params.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::BorshSchema for A<K, V>
 where
     K: borsh::BorshSchema,
@@ -43,4 +44,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_partial_skip.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -33,4 +34,3 @@ impl borsh::BorshSchema for A {
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/tuple_struct_whole_skip.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -27,4 +28,3 @@ impl borsh::BorshSchema for A {
         if no_recursion_flag {}
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/unit_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::BorshSchema for A {
     fn declaration() -> borsh::schema::Declaration {
         "A".to_string()
@@ -27,4 +28,3 @@ impl borsh::BorshSchema for A {
         if no_recursion_flag {}
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/with_funcs_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::BorshSchema for A<K, V>
 where
     K: borsh::BorshSchema,
@@ -43,4 +44,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
+++ b/borsh-derive/src/internals/schema/structs/snapshots/wrapper_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/schema/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T> borsh::BorshSchema for A<T>
 where
     T: borsh::BorshSchema,
@@ -37,4 +38,3 @@ where
         }
     }
 }
-

--- a/borsh-derive/src/internals/serialize/enums/mod.rs
+++ b/borsh-derive/src/internals/serialize/enums/mod.rs
@@ -44,6 +44,7 @@ pub fn process(input: &ItemEnum, cratename: Path) -> syn::Result<TokenStream2> {
     generics_output.extend(&mut where_clause, &cratename);
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #cratename::ser::BorshSerialize for #enum_ident #ty_generics #where_clause {
             fn serialize<__W: #cratename::io::Write>(&self, writer: &mut __W) -> ::core::result::Result<(), #cratename::io::Error> {
                 let variant_idx: u8 = match self {

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_false.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for X {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_discriminant_true.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for X {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_all_fields.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for AAB {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_struct_variant_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for AB {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/borsh_skip_tuple_variant_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for AATTB {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/bound_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::ser::BorshSerialize for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/check_serialize_with_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Ord, V> borsh::ser::BorshSerialize for C<K, V>
 where
     K: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_struct_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::ser::BorshSerialize for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_borsh_skip_tuple_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V, U> borsh::ser::BorshSerialize for A<K, V, U>
 where
     V: Value,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/generic_serialize_bound.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T: Debug, U> borsh::ser::BorshSerialize for A<T, U>
 where
     T: borsh::ser::BorshSerialize + PartialOrd,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/mixed_with_unit_variants.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/mixed_with_unit_variants.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for X {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/recursive_enum.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V> borsh::ser::BorshSerialize for A<K, V>
 where
     V: Value,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_enum_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::ser::BorshSerialize for AB {
     fn serialize<__W: reexporter::borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/simple_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::ser::BorshSerialize for A<K, V, U>
 where
     K: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
+++ b/borsh-derive/src/internals/serialize/enums/snapshots/struct_variant_field.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/enums/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for AB {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/structs/mod.rs
+++ b/borsh-derive/src/internals/serialize/structs/mod.rs
@@ -34,6 +34,7 @@ pub fn process(input: &ItemStruct, cratename: Path) -> syn::Result<TokenStream2>
     generics_output.extend(&mut where_clause, &cratename);
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics #cratename::ser::BorshSerialize for #name #ty_generics #where_clause {
             fn serialize<__W: #cratename::io::Write>(&self, writer: &mut __W) -> ::core::result::Result<(), #cratename::io::Error> {
                 #body

--- a/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/bound_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Key, V> borsh::ser::BorshSerialize for A<K, V>
 where
     V: Value,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/check_serialize_with_attr.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K: Ord, V> borsh::ser::BorshSerialize for A<K, V>
 where
     K: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_associated_type.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T, V> borsh::ser::BorshSerialize for Parametrized<T, V>
 where
     T: TraitName,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_named_fields_struct_borsh_skip.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::ser::BorshSerialize for G<K, V, U>
 where
     U: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_serialize_bound.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T: Debug, U> borsh::ser::BorshSerialize for C<T, U>
 where
     T: borsh::ser::BorshSerialize + PartialOrd,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip1.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::ser::BorshSerialize for G<K, V, U>
 where
     U: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/generic_tuple_struct_borsh_skip2.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V, U> borsh::ser::BorshSerialize for G<K, V, U>
 where
     K: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/override_generic_associated_type_wrong_derive.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T, V> borsh::ser::BorshSerialize for Parametrized<T, V>
 where
     T: TraitName,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/recursive_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for CRecC {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generic_tuple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<T> borsh::ser::BorshSerialize for TupleA<T>
 where
     T: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_generics.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl<K, V> borsh::ser::BorshSerialize for A<K, V>
 where
     K: borsh::ser::BorshSerialize,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl borsh::ser::BorshSerialize for A {
     fn serialize<__W: borsh::io::Write>(
         &self,

--- a/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
+++ b/borsh-derive/src/internals/serialize/structs/snapshots/simple_struct_with_custom_crate.snap
@@ -2,6 +2,7 @@
 source: borsh-derive/src/internals/serialize/structs/mod.rs
 expression: pretty_print_syn_str(&actual).unwrap()
 ---
+#[automatically_derived]
 impl reexporter::borsh::ser::BorshSerialize for A {
     fn serialize<__W: reexporter::borsh::io::Write>(
         &self,


### PR DESCRIPTION
Coverage reports (obtained by cargo-llvm-cov for example) rely on the presence of the  `#[automatically_derived]` attribute to skip derive macro blocks, however that attribute is missing in `borsh`’s derive macros.

This simply adds the `#[automatically_derived]` attribute on top of the `impl` blocks in the derive macros to fix this little problem.

Should have absolutely no impact in the behaviour of the crate other than that.