### PR TITLE
fix: add `indexmap` support

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -23,6 +23,10 @@ cargo test --features ascii,unstable__schema 'schema::test_ascii_strings'
 ########## features = ["rc"] group
 cargo test --features rc 'roundtrip::test_rc'
 cargo test --features rc,unstable__schema 'schema::test_rc'
+########## features = ["indexmap"] group
+cargo test --features indexmap 'roundtrip::test_indexmap'
+# checking with `derive` too just for the sake of redundancy https://github.com/near/borsh-rs/pull/346
+cargo test --features indexmap,derive 'roundtrip::test_indexmap'
 ########## features = ["de_strict_order"] group
 cargo test --features de_strict_order 'roundtrip::test_hash_map'
 cargo test --features de_strict_order 'roundtrip::test_btree_map'
@@ -44,6 +48,10 @@ cargo test --no-default-features --features ascii,unstable__schema 'schema::test
 ########## features = ["rc"] group
 cargo test --no-default-features --features rc 'roundtrip::test_rc'
 cargo test --no-default-features --features rc,unstable__schema 'schema::test_rc'
+########## features = ["indexmap"] group
+cargo test --no-default-features --features indexmap 'roundtrip::test_indexmap'
+# checking with `derive` too just for the sake of redundancy https://github.com/near/borsh-rs/pull/346
+cargo test --no-default-features --features indexmap,derive 'roundtrip::test_indexmap'
 ########## features = ["hashbrown"] group
 cargo test --no-default-features --features hashbrown
 cargo test --no-default-features --features hashbrown,derive

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,10 +36,10 @@ jobs:
       run: rustup default ${{ matrix.rust_version }}
     - name: print rustc version
       run: rustc --version
-    # - name: downgrade `toml_edit`, time`, `toml_datetime` crate to support older Rust toolchain
-    #   if: matrix.rust_version == '1.67.0' 
-    #   run: |
-    #     cargo update -p toml_edit --precise 0.21.0
+    - name: downgrade `serde_bytes` crate to support older Rust toolchain
+      if: matrix.rust_version == '1.67.0'
+      run: |
+        cargo update -p serde_bytes --precise 0.11.16
     - name: Run tests
       run: ./.github/test.sh
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
     - name: print rustc version
       run: rustc --version
     - name: downgrade `serde_bytes` crate to support older Rust toolchain
-      if: matrix.rust_version == '1.67.0'
+      if: matrix.rust_version == '1.67'
       run: |
         cargo update -p serde_bytes --precise 0.11.16
     - name: Run tests
@@ -52,8 +52,8 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
     # a failure on this check means, that some of `syn` crate's enums have been extended
     # with new variants.
-    # consult https://github.com/serde-rs/serde/blob/master/serde_derive/src/bound.rs#L100 , 
-    # the implementation of `FindTyParams` may have been updated already 
+    # consult https://github.com/serde-rs/serde/blob/master/serde_derive/src/bound.rs#L100 ,
+    # the implementation of `FindTyParams` may have been updated already
     - name: Run exhaustive check tests
       run: RUSTFLAGS="-A unused_imports -D warnings" cargo check --workspace --features force_exhaustive_checks
 

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -39,6 +39,7 @@ borsh-derive = { path = "../borsh-derive", version = "~1.5.5", optional = true }
 # sudden breaking changes with an open range of versions, so we limit the range by not yet released 0.16.0 version:
 hashbrown = { version = ">=0.11,<0.16.0", optional = true }
 bytes = { version = "1", optional = true }
+indexmap = { version = "2", optional = true }
 bson = { version = "2", optional = true }
 
 [dev-dependencies]

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -453,6 +453,39 @@ impl BorshDeserialize for bson::oid::ObjectId {
     }
 }
 
+#[cfg(feature = "indexmap")]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L39
+// license: MIT OR Apache-2.0
+impl<K, V, S> BorshDeserialize for indexmap::IndexMap<K, V, S>
+where
+    K: BorshDeserialize + Eq + core::hash::Hash,
+    V: BorshDeserialize,
+    S: core::hash::BuildHasher + Default,
+{
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        check_zst::<K>()?;
+        let vec = <Vec<(K, V)>>::deserialize_reader(reader)?;
+        Ok(vec.into_iter().collect::<indexmap::IndexMap<K, V, S>>())
+    }
+}
+
+#[cfg(feature = "indexmap")]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L75
+// license: MIT OR Apache-2.0
+impl<T, S> BorshDeserialize for indexmap::IndexSet<T, S>
+where
+    T: BorshDeserialize + Eq + core::hash::Hash,
+    S: core::hash::BuildHasher + Default,
+{
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        check_zst::<T>()?;
+        let vec = <Vec<T>>::deserialize_reader(reader)?;
+        Ok(vec.into_iter().collect::<indexmap::IndexSet<T, S>>())
+    }
+}
+
 impl<T> BorshDeserialize for Cow<'_, T>
 where
     T: ToOwned + ?Sized,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -317,6 +317,58 @@ impl BorshSerialize for bson::oid::ObjectId {
     }
 }
 
+#[cfg(feature = "indexmap")]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L74C1-L86C2
+// license: MIT OR Apache-2.0
+impl<T, S> BorshSerialize for indexmap::IndexSet<T, S>
+where
+    T: BorshSerialize,
+{
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        check_zst::<T>()?;
+
+        let iterator = self.iter();
+
+        u32::try_from(iterator.len())
+            .map_err(|_| ErrorKind::InvalidData)?
+            .serialize(writer)?;
+
+        for item in iterator {
+            item.serialize(writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "indexmap")]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L15
+// license: MIT OR Apache-2.0
+impl<K, V, S> BorshSerialize for indexmap::IndexMap<K, V, S>
+where
+    K: BorshSerialize,
+    V: BorshSerialize,
+{
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        check_zst::<K>()?;
+
+        let iterator = self.iter();
+
+        u32::try_from(iterator.len())
+            .map_err(|_| ErrorKind::InvalidData)?
+            .serialize(writer)?;
+
+        for (key, value) in iterator {
+            key.serialize(writer)?;
+            value.serialize(writer)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl<T> BorshSerialize for VecDeque<T>
 where
     T: BorshSerialize,

--- a/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_indexmap__indexmap_roundtrip.snap
+++ b/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_indexmap__indexmap_roundtrip.snap
@@ -1,0 +1,34 @@
+---
+source: borsh/tests/roundtrip/test_indexmap.rs
+expression: serialized_map
+---
+[
+    3,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    2,
+    0,
+    0,
+    0,
+    3,
+    0,
+    0,
+    0,
+    4,
+    0,
+    0,
+    0,
+    5,
+    0,
+    0,
+    0,
+    6,
+    0,
+    0,
+    0,
+]

--- a/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_indexmap__indexset_roundtrip.snap
+++ b/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_indexmap__indexset_roundtrip.snap
@@ -1,0 +1,34 @@
+---
+source: borsh/tests/roundtrip/test_indexmap.rs
+expression: serialized_set
+---
+[
+    6,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    2,
+    0,
+    0,
+    0,
+    3,
+    0,
+    0,
+    0,
+    4,
+    0,
+    0,
+    0,
+    5,
+    0,
+    0,
+    0,
+    6,
+    0,
+    0,
+    0,
+]

--- a/borsh/tests/roundtrip/test_indexmap.rs
+++ b/borsh/tests/roundtrip/test_indexmap.rs
@@ -1,0 +1,35 @@
+use borsh::BorshDeserialize;
+use indexmap::{IndexMap, IndexSet};
+
+
+#[test]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L100
+// license: MIT OR Apache-2.0
+fn test_indexmap_roundtrip() {
+	let original_map: IndexMap<i32, i32> = {
+		let mut map = IndexMap::new();
+		map.insert(1, 2);
+		map.insert(3, 4);
+		map.insert(5, 6);
+		map
+	};
+	let serialized_map = borsh::to_vec(&original_map).unwrap();
+	let deserialized_map: IndexMap<i32, i32> =
+		BorshDeserialize::try_from_slice(&serialized_map).unwrap();
+	assert_eq!(original_map, deserialized_map);
+}
+
+#[test]
+// Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L115
+// license: MIT OR Apache-2.0
+fn test_indexset_roundtrip() {
+	let mut original_set = IndexSet::new();
+	[1, 2, 3, 4, 5, 6].iter().for_each(|&i| {
+		original_set.insert(i);
+	});
+
+	let serialized_set = borsh::to_vec(&original_set).unwrap();
+	let deserialized_set: IndexSet<i32> =
+		BorshDeserialize::try_from_slice(&serialized_set).unwrap();
+	assert_eq!(original_set, deserialized_set);
+}

--- a/borsh/tests/roundtrip/test_indexmap.rs
+++ b/borsh/tests/roundtrip/test_indexmap.rs
@@ -1,35 +1,41 @@
 use borsh::BorshDeserialize;
 use indexmap::{IndexMap, IndexSet};
 
-
 #[test]
 // Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L100
 // license: MIT OR Apache-2.0
 fn test_indexmap_roundtrip() {
-	let original_map: IndexMap<i32, i32> = {
-		let mut map = IndexMap::new();
-		map.insert(1, 2);
-		map.insert(3, 4);
-		map.insert(5, 6);
-		map
-	};
-	let serialized_map = borsh::to_vec(&original_map).unwrap();
-	let deserialized_map: IndexMap<i32, i32> =
-		BorshDeserialize::try_from_slice(&serialized_map).unwrap();
-	assert_eq!(original_map, deserialized_map);
+    let original_map: IndexMap<i32, i32> = {
+        let mut map = IndexMap::new();
+        map.insert(1, 2);
+        map.insert(3, 4);
+        map.insert(5, 6);
+        map
+    };
+    let serialized_map = borsh::to_vec(&original_map).unwrap();
+    #[cfg(feature = "std")]
+    insta::assert_debug_snapshot!(serialized_map);
+
+    let deserialized_map: IndexMap<i32, i32> =
+        BorshDeserialize::try_from_slice(&serialized_map).unwrap();
+    assert_eq!(original_map, deserialized_map);
 }
 
 #[test]
 // Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L115
 // license: MIT OR Apache-2.0
 fn test_indexset_roundtrip() {
-	let mut original_set = IndexSet::new();
-	[1, 2, 3, 4, 5, 6].iter().for_each(|&i| {
-		original_set.insert(i);
-	});
+    let mut original_set = IndexSet::new();
+    [1, 2, 3, 4, 5, 6].iter().for_each(|&i| {
+        original_set.insert(i);
+    });
 
-	let serialized_set = borsh::to_vec(&original_set).unwrap();
-	let deserialized_set: IndexSet<i32> =
-		BorshDeserialize::try_from_slice(&serialized_set).unwrap();
-	assert_eq!(original_set, deserialized_set);
+    let serialized_set = borsh::to_vec(&original_set).unwrap();
+
+    #[cfg(feature = "std")]
+    insta::assert_debug_snapshot!(serialized_set);
+
+    let deserialized_set: IndexSet<i32> =
+        BorshDeserialize::try_from_slice(&serialized_set).unwrap();
+    assert_eq!(original_set, deserialized_set);
 }

--- a/borsh/tests/tests.rs
+++ b/borsh/tests/tests.rs
@@ -52,6 +52,8 @@ mod roundtrip {
     mod test_cells;
     #[cfg(feature = "rc")]
     mod test_rc;
+    #[cfg(feature = "indexmap")]
+    mod test_indexmap;
 
     #[cfg(feature = "derive")]
     mod requires_derive_category {


### PR DESCRIPTION
This PR fixes #345 by adding first-class indexmap support. This is necessary because `borsh` transitively depends on `indexmap`, so enabling the `borsh` feature of indexmap causes Rustc to complain about a circular dependency. 

---

recipe for import changes from 

```toml
borsh = { version = "1.5.5", features = ["derive"] }
indexmap = { version = "2.8.0", features = ["borsh"] }
```

to

```toml
borsh = { version = "1.5.5", features = ["derive", "indexmap"] }
indexmap = { version = "2.8.0" }
```