### PR TITLE
chore: replace `Result::unwrap` err msg with `proc_macro_crate::crate_name` tag

### DIFF
--- a/borsh-derive/src/internals/cratename.rs
+++ b/borsh-derive/src/internals/cratename.rs
@@ -18,7 +18,8 @@ pub(crate) fn get(attrs: &[Attribute]) -> Result<Path, Error> {
 }
 
 pub(crate) fn get_from_cargo() -> Ident {
-    let name = &crate_name(BORSH).unwrap();
+    let name = &crate_name(BORSH)
+        .unwrap_or_else(|err| panic!("`proc_macro_crate::crate_name` call error: {:#?}", err));
     let name = match name {
         FoundCrate::Itself => BORSH,
         FoundCrate::Name(name) => name.as_str(),


### PR DESCRIPTION
the following is easier to figure out with respect to originating lines and source of error: 
```
error: proc-macro derive panicked
 --> src/main.rs:8:26
  |
8 | #[derive(BorshSerialize, BorshDeserialize, BorshSchema)]
  |                          ^^^^^^^^^^^^^^^^
  |
  = help: message: `proc_macro_crate::crate_name` call error: Could not find `borsh` in `dependencies` or `dev-dependencies` in `/home/user/Documents/code/scratches/borsh_latest_check/Cargo.toml`!
  ```