### PR TITLE
Include license files in published crates

### DIFF
--- a/borsh-derive/LICENSE-APACHE
+++ b/borsh-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/borsh-derive/LICENSE-MIT
+++ b/borsh-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/borsh/LICENSE-APACHE
+++ b/borsh/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/borsh/LICENSE-MIT
+++ b/borsh/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Hi, thanks for Borsh! This PR symlinks the license files so they're included in published crates.