### PR TITLE
fix: keep bytes no_std unless borsh std is enabled

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -56,6 +56,8 @@ cargo test --no-default-features --features indexmap,derive 'roundtrip::test_ind
 cargo test --no-default-features --features hashbrown
 cargo test --no-default-features --features hashbrown,derive
 cargo test --no-default-features --features hashbrown,unstable__schema
+########## features = ["bytes"] group
+cargo test --no-default-features --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'
 popd
 pushd borsh-derive
 ############################ borsh-derive group #########################

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,11 @@ jobs:
     - name: downgrade crates to support older Rust toolchain
       if: matrix.rust_version == '1.77'
       run: |
-        cargo update -p indexmap@2.13.0 --precise 2.11.4
+        cargo update -p indexmap --precise 2.11.4
         cargo update -p time --precise 0.3.41
+        cargo update -p tempfile --precise 3.20.0
+        cargo update -p proc-macro-crate --precise 3.2.0
+        cargo update -p uuid --precise 1.17.0
     - name: Run tests
       run: ./.github/test.sh
 

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -38,7 +38,7 @@ borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get
 # sudden breaking changes with an open range of versions, so we limit the range by not yet released 0.16.0 version:
 hashbrown = { version = ">=0.11,<0.16.0", optional = true }
-bytes = { version = "1", optional = true }
+bytes = { version = "1", optional = true, default-features = false }
 indexmap = { version = "2", optional = true }
 bson = { version = "2", optional = true }
 
@@ -54,7 +54,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 default = ["std"]
 derive = ["borsh-derive"]
 unstable__schema = ["derive", "borsh-derive/schema"]
-std = []
+std = ["bytes?/std"]
 # Opt into impls for Rc<T> and Arc<T>. Serializing and deserializing these types
 # does not preserve identity and may result in multiple copies of the same data.
 # Be sure that this is what you want before enabling this feature.

--- a/borsh/docs/rustdoc_include/borsh_crate_top_level.md
+++ b/borsh/docs/rustdoc_include/borsh_crate_top_level.md
@@ -40,6 +40,8 @@
 * **bytes** -
   Gates implementation of [BorshSerialize] and [BorshDeserialize]
   for [Bytes](https://docs.rs/bytes/1.5.0/bytes/struct.Bytes.html) and [BytesMut](https://docs.rs/bytes/1.5.0/bytes/struct.BytesMut.html).
+  In `no_std` builds this keeps `bytes` in `no_std` mode; when **std** is enabled,
+  `bytes/std` is enabled as well.
 * **bson** -
   Gates implementation of [BorshSerialize] and [BorshDeserialize]
   for [ObjectId](https://docs.rs/bson/2.9.0/bson/oid/struct.ObjectId.html).


### PR DESCRIPTION
## Summary
- disable `bytes` default features in `borsh` so the optional `bytes` integration can compile in `no_std` builds
- re-enable `bytes/std` through `borsh/std` so std users keep the current behavior
- add a regression test entry for `--no-default-features --features bytes,derive`

## Test plan
- [x] `cargo test --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'`
- [x] `cargo test --no-default-features --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'`
- [x] `cargo tree -e features -i bytes --features bytes`
- [x] `cargo tree -e features -i bytes --no-default-features --features bytes`

## Notes
In the default configuration, `cargo tree` shows `bytes/std` enabled through `borsh/std`. With `--no-default-features --features bytes`, `bytes/std` is no longer activated.