### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1](https://github.com/near/borsh-rs/compare/borsh-v1.6.0...borsh-v1.6.1) - 2026-03-15
+
+### Fixed
+
+- keep bytes no_std unless borsh std is enabled ([#364](https://github.com/near/borsh-rs/pull/364))
+
 ## [1.6.0](https://github.com/near/borsh-rs/compare/borsh-v1.5.7...borsh-v1.6.0) - 2025-11-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.6.0"
+version = "1.6.1"
 rust-version = "1.77.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.6.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.6.1", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION



## 🤖 New release

* `borsh-derive`: 1.6.0 -> 1.6.1
* `borsh`: 1.6.0 -> 1.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `borsh`

<blockquote>

## [1.6.1](https://github.com/near/borsh-rs/compare/borsh-v1.6.0...borsh-v1.6.1) - 2026-03-15

### Fixed

- keep bytes no_std unless borsh std is enabled ([#364](https://github.com/near/borsh-rs/pull/364))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).