### PR TITLE
feat: impl `BorshSerialize` and `BorshDeserialize` for `Uuid`

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -34,7 +34,8 @@ cargo test --features de_strict_order 'roundtrip::test_btree_map'
 cargo test --features bson,derive 'roundtrip::requires_derive_category::test_bson_object_ids'
 ########## features = ["bytes"] group
 cargo test --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'
-
+########## features = ["uuid"] group
+cargo test --features uuid,derive 'roundtrip::test_uuid'
 
 ############################ borsh `default-features = false` group #########################
 ########## general group
@@ -58,6 +59,8 @@ cargo test --no-default-features --features hashbrown,derive
 cargo test --no-default-features --features hashbrown,unstable__schema
 ########## features = ["bytes"] group
 cargo test --no-default-features --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'
+########## features = ["uuid"] group
+cargo test --no-default-features --features uuid,derive 'roundtrip::test_uuid'
 popd
 pushd borsh-derive
 ############################ borsh-derive group #########################

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -41,6 +41,7 @@ hashbrown = { version = ">=0.11,<0.16.0", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 indexmap = { version = "2", optional = true }
 bson = { version = "2", optional = true }
+uuid = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 insta = "1.29.0"

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -486,6 +486,15 @@ where
     }
 }
 
+#[cfg(feature = "uuid")]
+impl BorshDeserialize for uuid::Uuid {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        Ok(uuid::Uuid::from_bytes(
+            BorshDeserialize::deserialize_reader(reader)?,
+        ))
+    }
+}
+
 impl<T> BorshDeserialize for Cow<'_, T>
 where
     T: ToOwned + ?Sized,

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -369,6 +369,15 @@ where
     }
 }
 
+#[cfg(feature = "uuid")]
+impl BorshSerialize for uuid::Uuid {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        BorshSerialize::serialize(&self.as_bytes(), writer)?;
+
+        Ok(())
+    }
+}
+
 impl<T> BorshSerialize for VecDeque<T>
 where
     T: BorshSerialize,

--- a/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_uuid__uuid_roundtrip.snap
+++ b/borsh/tests/roundtrip/snapshots/tests__roundtrip__test_uuid__uuid_roundtrip.snap
@@ -1,0 +1,22 @@
+---
+source: borsh/tests/roundtrip/test_uuid.rs
+expression: serialized_uuid
+---
+[
+    161,
+    162,
+    163,
+    164,
+    177,
+    178,
+    193,
+    194,
+    209,
+    210,
+    211,
+    212,
+    213,
+    214,
+    215,
+    216,
+]

--- a/borsh/tests/roundtrip/test_uuid.rs
+++ b/borsh/tests/roundtrip/test_uuid.rs
@@ -1,0 +1,17 @@
+use borsh::BorshDeserialize;
+use uuid::Uuid;
+
+#[test]
+fn test_uuid_roundtrip() {
+    let original_uuid = Uuid::from_bytes([
+        0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
+        0xd7, 0xd8,
+    ]);
+    let serialized_uuid = borsh::to_vec(&original_uuid).unwrap();
+    #[cfg(feature = "std")]
+    insta::assert_debug_snapshot!(serialized_uuid);
+
+    let deserialized_uuid: Uuid =
+        BorshDeserialize::try_from_slice(&serialized_uuid).unwrap();
+    assert_eq!(original_uuid, deserialized_uuid);
+}

--- a/borsh/tests/tests.rs
+++ b/borsh/tests/tests.rs
@@ -53,6 +53,8 @@ mod roundtrip {
     mod test_rc;
     #[cfg(feature = "indexmap")]
     mod test_indexmap;
+    #[cfg(feature = "uuid")]
+    mod test_uuid;
 
     #[cfg(feature = "derive")]
     mod requires_derive_category {


### PR DESCRIPTION
For #363, https://github.com/uuid-rs/uuid/issues/860

This PR adds `uuid` support to `borsh` itself, so we can work towards removing our support from `uuid` to break dependency cycles between them. It's a bit of an unfortunate situation to be in, but this is the best we can do with the tools the language currently gives us :slightly_smiling_face: 

I've tried to follow the conventions I found in the project but let me know if I missed anything or if anything should be done differently.