### PR TITLE
feat: add uuid support

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -34,6 +34,8 @@ cargo test --features de_strict_order 'roundtrip::test_btree_map'
 cargo test --features bson,derive 'roundtrip::requires_derive_category::test_bson_object_ids'
 ########## features = ["bytes"] group
 cargo test --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'
+########## features = ["uuid"] group
+cargo test --features uuid 'roundtrip::test_uuid'
 
 
 ############################ borsh `default-features = false` group #########################
@@ -58,6 +60,8 @@ cargo test --no-default-features --features hashbrown,derive
 cargo test --no-default-features --features hashbrown,unstable__schema
 ########## features = ["bytes"] group
 cargo test --no-default-features --features bytes,derive 'roundtrip::requires_derive_category::test_ultimate_many_features_combined'
+########## features = ["uuid"] group
+cargo test --no-default-features --features uuid 'roundtrip::test_uuid'
 popd
 pushd borsh-derive
 ############################ borsh-derive group #########################

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,12 @@ jobs:
     - name: downgrade crates to support older Rust toolchain
       if: matrix.rust_version == '1.77'
       run: |
+        # proc-macro-crate must come first: it pins toml_edit/indexmap down to
+        # versions that still build on 1.77 (newer toml_edit needs indexmap >=2.13).
+        cargo update -p proc-macro-crate --precise 3.2.0
         cargo update -p indexmap --precise 2.11.4
         cargo update -p time --precise 0.3.41
         cargo update -p tempfile --precise 3.20.0
-        cargo update -p proc-macro-crate --precise 3.2.0
         cargo update -p uuid --precise 1.17.0
     - name: Run tests
       run: ./.github/test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
+# benchmarks and fuzz need extra features to build, so keep them out of bare
+# `cargo` invocations from the workspace root; the test scripts target them explicitly.
+default-members = ["borsh", "borsh-derive"]
 
 [workspace.package]
 # shared version of all public crates in the workspace

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -41,6 +41,7 @@ hashbrown = { version = ">=0.11,<0.16.0", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 indexmap = { version = "2", optional = true }
 bson = { version = "2", optional = true }
+uuid = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 insta = "1.29.0"

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -374,9 +374,9 @@ pub mod ascii {
     //!
     //! Module defines [BorshDeserialize] implementation for
     //! some types from [ascii](::ascii) crate.
-    use crate::BorshDeserialize;
     use crate::__private::maybestd::{string::ToString, vec::Vec};
     use crate::io::{Error, ErrorKind, Read, Result};
+    use crate::BorshDeserialize;
 
     impl BorshDeserialize for ascii::AsciiString {
         #[inline]
@@ -527,10 +527,10 @@ where
 pub mod hashes {
     use core::hash::{BuildHasher, Hash};
 
-    use crate::BorshDeserialize;
     use crate::__private::maybestd::collections::{HashMap, HashSet};
     use crate::__private::maybestd::vec::Vec;
     use crate::io::{Read, Result};
+    use crate::BorshDeserialize;
 
     #[cfg(feature = "de_strict_order")]
     const ERROR_WRONG_ORDER_OF_KEYS: &str = "keys were not serialized in ascending order";

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -453,6 +453,16 @@ impl BorshDeserialize for bson::oid::ObjectId {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl BorshDeserialize for uuid::Uuid {
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        Ok(uuid::Uuid::from_bytes(<[u8; 16]>::deserialize_reader(
+            reader,
+        )?))
+    }
+}
+
 #[cfg(feature = "indexmap")]
 // Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L39
 // license: MIT OR Apache-2.0

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,6 +1,6 @@
-use crate::BorshSerialize;
 use crate::__private::maybestd::vec::Vec;
 use crate::io::{ErrorKind, Result, Write};
+use crate::BorshSerialize;
 
 pub(super) const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
 

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -432,7 +432,7 @@ pub mod hashes {
             check_zst::<K>()?;
 
             let mut vec = self.iter().collect::<Vec<_>>();
-            vec.sort_by(|(a, _), (b, _)| a.cmp(b));
+            vec.sort_by_key(|(a, _)| *a);
             u32::try_from(vec.len())
                 .map_err(|_| ErrorKind::InvalidData)?
                 .serialize(writer)?;

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -413,8 +413,8 @@ pub mod hashes {
     use crate::__private::maybestd::vec::Vec;
     use crate::error::check_zst;
     use crate::{
-        BorshSerialize,
         __private::maybestd::collections::{HashMap, HashSet},
+        BorshSerialize,
     };
     use core::convert::TryFrom;
     use core::hash::BuildHasher;

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -317,6 +317,14 @@ impl BorshSerialize for bson::oid::ObjectId {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl BorshSerialize for uuid::Uuid {
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.as_bytes().serialize(writer)
+    }
+}
+
 #[cfg(feature = "indexmap")]
 // Taken from https://github.com/indexmap-rs/indexmap/blob/dd06e5773e4f91748396c67d00c83637f5c0dd49/src/borsh.rs#L74C1-L86C2
 // license: MIT OR Apache-2.0

--- a/borsh/tests/roundtrip/test_uuid.rs
+++ b/borsh/tests/roundtrip/test_uuid.rs
@@ -1,0 +1,17 @@
+use borsh::BorshDeserialize;
+use uuid::Uuid;
+
+#[test]
+fn test_uuid_roundtrip() {
+    let original_uuid = Uuid::from_bytes([
+        0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7,
+        0xd8,
+    ]);
+    let serialized_uuid = borsh::to_vec(&original_uuid).unwrap();
+
+    // Borsh encodes a `Uuid` as its raw 16 bytes, no length prefix.
+    assert_eq!(serialized_uuid.as_slice(), original_uuid.as_bytes());
+
+    let deserialized_uuid = Uuid::try_from_slice(&serialized_uuid).unwrap();
+    assert_eq!(original_uuid, deserialized_uuid);
+}

--- a/borsh/tests/tests.rs
+++ b/borsh/tests/tests.rs
@@ -53,6 +53,8 @@ mod roundtrip {
     mod test_rc;
     #[cfg(feature = "indexmap")]
     mod test_indexmap;
+    #[cfg(feature = "uuid")]
+    mod test_uuid;
 
     #[cfg(feature = "derive")]
     mod requires_derive_category {


### PR DESCRIPTION
Adds a `uuid` feature so borsh implements `BorshSerialize`/`BorshDeserialize` for `Uuid` directly, instead of uuid depending on borsh.

Context in #363 and uuid-rs/uuid#860: enabling uuid's `borsh` feature together with borsh's `bson` feature creates a uuid -> borsh -> bson -> uuid cycle. Putting the impls here lets uuid deprecate its own `borsh` feature so the loop goes away.

Same approach as #366, redone off a clean master with the compile errors fixed and the unrelated import churn dropped.

`Uuid` encodes as its raw 16 bytes, no length prefix. Works under no_std.

Draft for now: while both `uuid/borsh` and `borsh/uuid` exist, turning both on at once is itself a cycle, so ideally this lands alongside uuid switching their feature to a no-op rather than a soft deprecation that still links borsh.
