### PR TITLE
ci: fix the build on current toolchains

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,12 @@ jobs:
     - name: downgrade crates to support older Rust toolchain
       if: matrix.rust_version == '1.77'
       run: |
+        # proc-macro-crate must come first: it pins toml_edit/indexmap down to
+        # versions that still build on 1.77 (newer toml_edit needs indexmap >=2.13).
+        cargo update -p proc-macro-crate --precise 3.2.0
         cargo update -p indexmap --precise 2.11.4
         cargo update -p time --precise 0.3.41
         cargo update -p tempfile --precise 3.20.0
-        cargo update -p proc-macro-crate --precise 3.2.0
         cargo update -p uuid --precise 1.17.0
     - name: Run tests
       run: ./.github/test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
 # benchmarks and fuzz need extra features to build, so keep them out of bare
-# `cargo` invocations from the workspace root; the test scripts target them explicitly.
+# `cargo` invocations from the workspace root.
 default-members = ["borsh", "borsh-derive"]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = ["borsh", "borsh-derive", "fuzz/fuzz-run", "benchmarks"]
+# benchmarks and fuzz need extra features to build, so keep them out of bare
+# `cargo` invocations from the workspace root; the test scripts target them explicitly.
+default-members = ["borsh", "borsh-derive"]
 
 [workspace.package]
 # shared version of all public crates in the workspace

--- a/borsh/src/de/mod.rs
+++ b/borsh/src/de/mod.rs
@@ -374,9 +374,9 @@ pub mod ascii {
     //!
     //! Module defines [BorshDeserialize] implementation for
     //! some types from [ascii](::ascii) crate.
-    use crate::BorshDeserialize;
     use crate::__private::maybestd::{string::ToString, vec::Vec};
     use crate::io::{Error, ErrorKind, Read, Result};
+    use crate::BorshDeserialize;
 
     impl BorshDeserialize for ascii::AsciiString {
         #[inline]
@@ -527,10 +527,10 @@ where
 pub mod hashes {
     use core::hash::{BuildHasher, Hash};
 
-    use crate::BorshDeserialize;
     use crate::__private::maybestd::collections::{HashMap, HashSet};
     use crate::__private::maybestd::vec::Vec;
     use crate::io::{Read, Result};
+    use crate::BorshDeserialize;
 
     #[cfg(feature = "de_strict_order")]
     const ERROR_WRONG_ORDER_OF_KEYS: &str = "keys were not serialized in ascending order";

--- a/borsh/src/ser/helpers.rs
+++ b/borsh/src/ser/helpers.rs
@@ -1,6 +1,6 @@
-use crate::BorshSerialize;
 use crate::__private::maybestd::vec::Vec;
 use crate::io::{ErrorKind, Result, Write};
+use crate::BorshSerialize;
 
 pub(super) const DEFAULT_SERIALIZER_CAPACITY: usize = 1024;
 

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -432,7 +432,7 @@ pub mod hashes {
             check_zst::<K>()?;
 
             let mut vec = self.iter().collect::<Vec<_>>();
-            vec.sort_by(|(a, _), (b, _)| a.cmp(b));
+            vec.sort_by_key(|(a, _)| *a);
             u32::try_from(vec.len())
                 .map_err(|_| ErrorKind::InvalidData)?
                 .serialize(writer)?;

--- a/borsh/src/ser/mod.rs
+++ b/borsh/src/ser/mod.rs
@@ -413,8 +413,8 @@ pub mod hashes {
     use crate::__private::maybestd::vec::Vec;
     use crate::error::check_zst;
     use crate::{
-        BorshSerialize,
         __private::maybestd::collections::{HashMap, HashSet},
+        BorshSerialize,
     };
     use core::convert::TryFrom;
     use core::hash::BuildHasher;


### PR DESCRIPTION
Master's CI has been red on current toolchains for a while. Nothing's merged since March so nobody noticed, but every new PR hits it. This gets it green again.

- 1.77 job: the MSRV downgrade list pinned indexmap before proc-macro-crate, but newer proc-macro-crate pulls in a toml_edit that wants indexmap >=2.13, so the 2.11.4 pin couldn't resolve. Pinning proc-macro-crate first sorts it out.
- clippy: a newer lint (unnecessary_sort_by) trips on the HashMap serialize, and -D warnings makes it fatal. Switched to sort_by_key.
- fmt: reran rustfmt, since the import ordering changed since master was last formatted.

I also added default-members so a bare cargo from the root skips benchmarks and fuzz (they need extra features to build). Side effect: clippy no longer covers the benchmarks crate.

These jobs run on unpinned stable, so this'll come back as stable moves. Happy to pin them in a follow-up.
