### PR TITLE
fix: handle PhantomData in enum schema derive

### DIFF
--- a/borsh-derive/src/internals/generics.rs
+++ b/borsh-derive/src/internals/generics.rs
@@ -50,17 +50,22 @@ pub fn without_defaults(generics: &Generics) -> Generics {
 }
 
 #[cfg(feature = "schema")]
-pub fn type_contains_some_param(
-    type_: &Type,
-    params: &HashSet<Ident>,
+pub fn where_predicate_contains_only_params(
+    predicate: &WherePredicate,
+    all_params: &HashSet<Ident>,
+    allowed_params: &HashSet<Ident>,
     include_phantom_data: bool,
 ) -> bool {
-    let mut find: FindTyParams = FindTyParams::from_params(params.iter());
+    let mut find = FindTyParams::from_params(all_params.iter());
     find.include_phantom_data = include_phantom_data;
 
-    find.visit_type_top_level(type_);
+    find.visit_where_predicate(predicate);
 
-    find.at_least_one_hit()
+    let used_params = find.process_for_params();
+    !used_params.is_empty()
+        && used_params
+            .iter()
+            .all(|param| allowed_params.contains(param))
 }
 
 /// a Visitor-like struct, which helps determine, if a type parameter is found in field
@@ -178,9 +183,6 @@ impl FindTyParams {
         });
         params
     }
-    pub fn at_least_one_hit(&self) -> bool {
-        !self.relevant_type_params.is_empty() || !self.associated_type_params_usage.is_empty()
-    }
 }
 
 impl FindTyParams {
@@ -280,6 +282,24 @@ impl FindTyParams {
             _ => {}
         }
     }
+
+    fn visit_where_predicate(&mut self, predicate: &WherePredicate) {
+        #[cfg_attr(
+            feature = "force_exhaustive_checks",
+            deny(non_exhaustive_omitted_patterns)
+        )]
+        match predicate {
+            WherePredicate::Type(predicate_type) => {
+                self.visit_type_top_level(&predicate_type.bounded_ty);
+                for bound in &predicate_type.bounds {
+                    self.visit_type_param_bound(bound);
+                }
+            }
+            WherePredicate::Lifetime(_) => {}
+            _ => {}
+        }
+    }
+
     // Type parameter should not be considered used by a macro path.
     //
     //     struct TypeMacro<T> {

--- a/borsh-derive/src/internals/generics.rs
+++ b/borsh-derive/src/internals/generics.rs
@@ -50,8 +50,13 @@ pub fn without_defaults(generics: &Generics) -> Generics {
 }
 
 #[cfg(feature = "schema")]
-pub fn type_contains_some_param(type_: &Type, params: &HashSet<Ident>) -> bool {
+pub fn type_contains_some_param(
+    type_: &Type,
+    params: &HashSet<Ident>,
+    include_phantom_data: bool,
+) -> bool {
     let mut find: FindTyParams = FindTyParams::from_params(params.iter());
+    find.include_phantom_data = include_phantom_data;
 
     find.visit_type_top_level(type_);
 
@@ -71,6 +76,8 @@ pub struct FindTyParams {
 
     // [Param] => [Type, containing Param] mapping
     associated_type_params_usage: HashMap<Ident, Vec<Type>>,
+
+    include_phantom_data: bool,
 }
 
 fn ungroup(mut ty: &Type) -> &Type {
@@ -97,6 +104,7 @@ impl FindTyParams {
             all_type_params_ordered,
             relevant_type_params: HashSet::new(),
             associated_type_params_usage: HashMap::new(),
+            include_phantom_data: false,
         }
     }
     pub fn process_for_bounds(self) -> Vec<Type> {
@@ -142,7 +150,14 @@ impl FindTyParams {
             all_type_params_ordered,
             relevant_type_params: HashSet::new(),
             associated_type_params_usage: HashMap::new(),
+            include_phantom_data: false,
         }
+    }
+
+    pub fn new_including_phantom_data(generics: &Generics) -> Self {
+        let mut find = Self::new(generics);
+        find.include_phantom_data = true;
+        find
     }
 
     pub fn process_for_params(self) -> Vec<Ident> {
@@ -235,7 +250,7 @@ impl FindTyParams {
 
     fn visit_path(&mut self, path: &Path) {
         if let Some(seg) = path.segments.last() {
-            if seg.ident == "PhantomData" {
+            if seg.ident == "PhantomData" && !self.include_phantom_data {
                 // Hardcoded exception, because PhantomData<T> implements
                 // Serialize and Deserialize and Schema whether or not T implements it.
                 return;

--- a/borsh-derive/src/internals/generics.rs
+++ b/borsh-derive/src/internals/generics.rs
@@ -283,6 +283,7 @@ impl FindTyParams {
         }
     }
 
+    #[cfg(feature = "schema")]
     fn visit_where_predicate(&mut self, predicate: &WherePredicate) {
         #[cfg_attr(
             feature = "force_exhaustive_checks",

--- a/borsh-derive/src/internals/schema/enums/mod.rs
+++ b/borsh-derive/src/internals/schema/enums/mod.rs
@@ -152,7 +152,8 @@ fn inner_struct_definition(
 ) -> (TokenStream2, Generics) {
     let transformed_fields = transform_variant_fields(variant.fields.clone());
 
-    let mut variant_schema_params_visitor = generics::FindTyParams::new(enum_generics);
+    let mut variant_schema_params_visitor =
+        generics::FindTyParams::new_including_phantom_data(enum_generics);
     schema::visit_struct_fields_unconditional(&variant.fields, &mut variant_schema_params_visitor);
     let variant_not_skipped_params = variant_schema_params_visitor
         .process_for_params()

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -60,6 +60,10 @@ fn declaration(ident_str: &str, cratename: Path, params_for_bounds: Vec<Type>) -
 }
 
 fn filter_used_params(generics: &Generics, not_skipped_type_params: HashSet<Ident>) -> Generics {
+    let all_type_params = generics
+        .type_params()
+        .map(|param| param.ident.clone())
+        .collect::<HashSet<_>>();
     let new_params = generics
         .params
         .clone()
@@ -82,8 +86,9 @@ fn filter_used_params(generics: &Generics, not_skipped_type_params: HashSet<Iden
                 )]
                 match predicate {
                     WherePredicate::Lifetime(..) => true,
-                    WherePredicate::Type(predicate_type) => generics::type_contains_some_param(
-                        &predicate_type.bounded_ty,
+                    WherePredicate::Type(..) => generics::where_predicate_contains_only_params(
+                        predicate,
+                        &all_type_params,
                         &not_skipped_type_params,
                         true,
                     ),

--- a/borsh-derive/src/internals/schema/mod.rs
+++ b/borsh-derive/src/internals/schema/mod.rs
@@ -85,6 +85,7 @@ fn filter_used_params(generics: &Generics, not_skipped_type_params: HashSet<Iden
                     WherePredicate::Type(predicate_type) => generics::type_contains_some_param(
                         &predicate_type.bounded_ty,
                         &not_skipped_type_params,
+                        true,
                     ),
 
                     _ => true,

--- a/borsh/tests/schema/test_phantom_data.rs
+++ b/borsh/tests/schema/test_phantom_data.rs
@@ -45,3 +45,37 @@ pub fn generic_struct_with_phantom_data_derived() {
         defs
     );
 }
+
+#[test]
+pub fn generic_enum_variant_with_phantom_data_derived() {
+    #[allow(unused)]
+    #[derive(borsh::BorshSchema)]
+    enum Parametrized<T> {
+        Item(PhantomData<T>),
+    }
+
+    struct Marker;
+
+    assert_eq!(
+        "Parametrized".to_string(),
+        <Parametrized<Marker>>::declaration()
+    );
+
+    let mut defs = Default::default();
+    <Parametrized<Marker>>::add_definitions_recursively(&mut defs);
+    assert_eq!(
+        schema_map! {
+            "Parametrized" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    (0, "Item".to_string(), "Parametrized__Item".to_string()),
+                ],
+            },
+            "Parametrized__Item" => Definition::Struct {
+                fields: Fields::UnnamedFields(vec!["()".to_string()])
+            },
+            "()" => Definition::Primitive(0)
+        },
+        defs
+    );
+}

--- a/borsh/tests/schema/test_phantom_data.rs
+++ b/borsh/tests/schema/test_phantom_data.rs
@@ -79,3 +79,45 @@ pub fn generic_enum_variant_with_phantom_data_derived() {
         defs
     );
 }
+
+#[test]
+pub fn generic_enum_variant_with_mixed_phantom_data_predicate_derived() {
+    #[allow(unused)]
+    #[derive(borsh::BorshSchema)]
+    enum Parametrized<T, U>
+    where
+        PhantomData<(T, U)>: Clone,
+    {
+        Item(PhantomData<T>),
+        Other(PhantomData<U>),
+    }
+
+    struct Marker;
+
+    assert_eq!(
+        "Parametrized".to_string(),
+        <Parametrized<Marker, Marker>>::declaration()
+    );
+
+    let mut defs = Default::default();
+    <Parametrized<Marker, Marker>>::add_definitions_recursively(&mut defs);
+    assert_eq!(
+        schema_map! {
+            "Parametrized" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    (0, "Item".to_string(), "Parametrized__Item".to_string()),
+                    (1, "Other".to_string(), "Parametrized__Other".to_string()),
+                ],
+            },
+            "Parametrized__Item" => Definition::Struct {
+                fields: Fields::UnnamedFields(vec!["()".to_string()])
+            },
+            "Parametrized__Other" => Definition::Struct {
+                fields: Fields::UnnamedFields(vec!["()".to_string()])
+            },
+            "()" => Definition::Primitive(0)
+        },
+        defs
+    );
+}


### PR DESCRIPTION
Fixes #329.

This fixes `#[derive(BorshSchema)]` for enum variants that contain `PhantomData<T>`.

What changed:
- added a schema-only mode for generic parameter detection that can include `PhantomData<T>` when enum variant schema params are computed
- kept the existing `PhantomData<T>` skip behavior for the other derive paths
- added a regression test for `enum Parametrized<T> { Item(PhantomData<T>) }` using a marker type that does not implement `BorshSchema`

Why:
The struct case already works, but the enum variant case from #329 expands into code that tries to use the outer generic parameter from a generated inner item. I checked this with a throwaway crate: clean `origin/master` fails with `E0401`, while the patched local Borsh passes and can call `MyEnum::<NotSchema>::add_definitions_recursively`.

Checked:
- `cargo test -p borsh --features unstable__schema schema::test_phantom_data`
- `cargo test -p borsh --features unstable__schema schema::test_generic_enums`
- `cargo test -p borsh --features unstable__schema`
- `cargo test -p borsh-derive --features schema`
- `cargo fmt --check`
- `cargo clippy -p borsh-derive --features schema -- -D warnings`
- `cargo clippy -p borsh --features unstable__schema -- -D warnings`