### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/near/borsh-rs/compare/borsh-v1.6.1...borsh-v1.7.0) - 2026-06-17
+
+### Added
+
+- impl `BorshSerialize` and `BorshDeserialize` for `Uuid` ([#366](https://github.com/near/borsh-rs/pull/366))
+
+### Fixed
+
+- handle PhantomData in enum schema derive ([#369](https://github.com/near/borsh-rs/pull/369))
+
+### Other
+
+- cover schema predicate bounds referencing filtered enum params ([#372](https://github.com/near/borsh-rs/pull/372))
+- fix the build on current toolchains ([#368](https://github.com/near/borsh-rs/pull/368))
+
 ## [1.6.1](https://github.com/near/borsh-rs/compare/borsh-v1.6.0...borsh-v1.6.1) - 2026-03-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ default-members = ["borsh", "borsh-derive"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.6.1"
+version = "1.7.0"
 rust-version = "1.77.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.6.1", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.7.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION



## 🤖 New release

* `borsh-derive`: 1.6.1 -> 1.7.0
* `borsh`: 1.6.1 -> 1.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `borsh`

<blockquote>

## [1.7.0](https://github.com/near/borsh-rs/compare/borsh-v1.6.1...borsh-v1.7.0) - 2026-06-17

### Added

- impl `BorshSerialize` and `BorshDeserialize` for `Uuid` ([#366](https://github.com/near/borsh-rs/pull/366))

### Fixed

- handle PhantomData in enum schema derive ([#369](https://github.com/near/borsh-rs/pull/369))

### Other

- cover schema predicate bounds referencing filtered enum params ([#372](https://github.com/near/borsh-rs/pull/372))
- fix the build on current toolchains ([#368](https://github.com/near/borsh-rs/pull/368))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).