### PR TITLE
ci: use org-level NEARPROTOCOL_CI_PR_ACCESS token for release-plz

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,12 +99,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

The `release-plz` job has been failing on every `master` push since June 2 ([example run](https://github.com/near/borsh-rs/actions/runs/26839411618/job/79142535080)):

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Root cause: the repo-level `CUSTOM_GITHUB_TOKEN` secret was a personal PAT (set 2023-05-31) that expired sometime between the last successful release run (2026-03-18, v1.6.1) and 2026-06-02.

## Fix

Switch the job to the org-level `NEARPROTOCOL_CI_PR_ACCESS` secret (the `nearprotocol-ci` bot token):

- already shared with this repo at the org level, and the bot has access to this repo
- the same secret near-sdk-rs uses for its release-plz job (last successful release with it: 2026-05-27)
- org-managed rotation, so releases no longer depend on an individual's PAT expiry

## Follow-up after merge

- Delete the now-unused repo-level `CUSTOM_GITHUB_TOKEN` secret
- Revoke the stopgap PAT created to unblock today's run