### PR TITLE
test: cover schema predicate bounds referencing filtered enum params

### DIFF
--- a/borsh/tests/schema/test_generic_enums.rs
+++ b/borsh/tests/schema/test_generic_enums.rs
@@ -275,3 +275,43 @@ pub fn generic_associated_item2() {
 
     assert_eq!(common_map_associated(), defs);
 }
+
+#[test]
+pub fn generic_enum_with_predicate_bound_referencing_filtered_param() {
+    #[allow(unused)]
+    #[derive(borsh::BorshSchema)]
+    enum Parametrized<T, U>
+    where
+        T: From<U>,
+    {
+        V1(T),
+        V2(U),
+    }
+
+    assert_eq!(
+        "Parametrized<u64, u32>".to_string(),
+        <Parametrized<u64, u32>>::declaration()
+    );
+    let mut defs = Default::default();
+    <Parametrized<u64, u32>>::add_definitions_recursively(&mut defs);
+    assert_eq!(
+        schema_map! {
+            "Parametrized<u64, u32>" => Definition::Enum {
+                tag_width: 1,
+                variants: vec![
+                    (0, "V1".to_string(), "Parametrized__V1<u64>".to_string()),
+                    (1, "V2".to_string(), "Parametrized__V2<u32>".to_string()),
+                ],
+            },
+            "Parametrized__V1<u64>" => Definition::Struct {
+                fields: Fields::UnnamedFields(vec!["u64".to_string()])
+            },
+            "Parametrized__V2<u32>" => Definition::Struct {
+                fields: Fields::UnnamedFields(vec!["u32".to_string()])
+            },
+            "u64" => Definition::Primitive(8),
+            "u32" => Definition::Primitive(4)
+        },
+        defs
+    );
+}


### PR DESCRIPTION
Fast-follow to #369.

The fix in #369 went further than the `PhantomData` case: because `where_predicate_contains_only_params` visits a predicate's *bounds* (not just the bounded type), it also fixed enums like

```rust
#[derive(BorshSchema)]
enum Parametrized<T, U>
where
    T: From<U>,
{
    V1(T),
    V2(U),
}
```

On pre-#369 master this failed with `E0401`: the old filter kept `T: From<U>` for `V1`'s generated inner struct because the bounded type `T` matched, leaving a dangling `U` in the bound.

That behavior was only covered indirectly, so this adds a regression test to lock in the bounds-visiting. Verified it passes on current master and fails with `E0401` when run against pre-#369 master.