### PR TITLE
feat: merge multiple `#[borsh(...)]` attributes instead of rejecting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- merge multiple `#[borsh(...)]` attributes instead of rejecting them ([#373](https://github.com/near/borsh-rs/pull/373))
+
 ## [1.7.0](https://github.com/near/borsh-rs/compare/borsh-v1.6.1...borsh-v1.7.0) - 2026-06-17
 
 ### Added

--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -6,8 +6,8 @@ use syn::{meta::ParseNestedMeta, Attribute, WherePredicate};
 use self::bounds::BOUNDS_FIELD_PARSE_MAP;
 
 use super::{
-    get_one_attribute,
-    parsing::{attr_get_by_symbol_keys, meta_get_by_symbol_keys, parse_lit_into},
+    collect_borsh_attributes,
+    parsing::{attrs_get_by_symbol_keys, meta_get_by_symbol_keys, parse_lit_into},
     BoundType, Symbol, BORSH, BOUND, DESERIALIZE_WITH, SERIALIZE_WITH, SKIP,
 };
 
@@ -152,11 +152,12 @@ impl Attributes {
         Ok(())
     }
     pub(crate) fn parse(attrs: &[Attribute]) -> Result<Self, syn::Error> {
-        let borsh = get_one_attribute(attrs)?;
+        let borsh_attrs = collect_borsh_attributes(attrs);
 
-        let result: Self = if let Some(attr) = borsh {
-            let result: Self = attr_get_by_symbol_keys(BORSH, attr, &BORSH_FIELD_PARSE_MAP)?.into();
-            result.check(attr)?;
+        let result: Self = if let Some(first_attr) = borsh_attrs.first() {
+            let result: Self =
+                attrs_get_by_symbol_keys(BORSH, &borsh_attrs, &BORSH_FIELD_PARSE_MAP)?.into();
+            result.check(first_attr)?;
             result
         } else {
             BTreeMap::new().into()
@@ -256,15 +257,29 @@ mod tests {
     use super::{bounds, Attributes};
 
     #[test]
-    fn test_reject_multiple_borsh_attrs() {
+    fn test_merge_multiple_borsh_attrs() {
         let item_struct: ItemStruct = syn::parse2(quote! {
             struct A {
-                #[borsh(skip)]
-                #[borsh(bound(deserialize = "K: Hash + Ord,
-                     V: Eq + Ord",
-                    serialize = "K: Hash + Eq + Ord,
-                     V: Ord"
-                ))]
+                #[borsh(serialize_with = "third_party_impl::serialize_third_party")]
+                #[borsh(deserialize_with = "third_party_impl::deserialize_third_party")]
+                x: u64,
+                y: String,
+            }
+        })
+        .unwrap();
+
+        let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
+        let attrs = Attributes::parse(&first_field.attrs).unwrap();
+        local_insta_assert_snapshot!(debug_print_tokenizable(attrs.serialize_with.as_ref()));
+        local_insta_assert_snapshot!(debug_print_tokenizable(attrs.deserialize_with));
+    }
+
+    #[test]
+    fn test_reject_duplicate_key_across_borsh_attrs() {
+        let item_struct: ItemStruct = syn::parse2(quote! {
+            struct A {
+                #[borsh(serialize_with = "third_party_impl::serialize_third_party")]
+                #[borsh(serialize_with = "third_party_impl::serialize_third_party")]
                 x: u64,
                 y: String,
             }

--- a/borsh-derive/src/internals/attributes/field/mod.rs
+++ b/borsh-derive/src/internals/attributes/field/mod.rs
@@ -295,6 +295,28 @@ mod tests {
     }
 
     #[test]
+    fn test_reject_duplicate_key_within_single_borsh_attr() {
+        let item_struct: ItemStruct = syn::parse2(quote! {
+            struct A {
+                #[borsh(
+                    serialize_with = "third_party_impl::serialize_third_party",
+                    serialize_with = "third_party_impl::serialize_third_party",
+                )]
+                x: u64,
+                y: String,
+            }
+        })
+        .unwrap();
+
+        let first_field = &item_struct.fields.into_iter().collect::<Vec<_>>()[0];
+        let err = match Attributes::parse(&first_field.attrs) {
+            Ok(..) => unreachable!("expecting error here"),
+            Err(err) => err,
+        };
+        local_insta_assert_debug_snapshot!(err);
+    }
+
+    #[test]
     fn test_bounds_parsing1() {
         let item_struct: ItemStruct = syn::parse2(quote! {
             struct A {

--- a/borsh-derive/src/internals/attributes/field/snapshots/merge_multiple_borsh_attrs-2.snap
+++ b/borsh-derive/src/internals/attributes/field/snapshots/merge_multiple_borsh_attrs-2.snap
@@ -1,0 +1,5 @@
+---
+source: borsh-derive/src/internals/attributes/field/mod.rs
+expression: debug_print_tokenizable(attrs.deserialize_with)
+---
+third_party_impl :: deserialize_third_party

--- a/borsh-derive/src/internals/attributes/field/snapshots/merge_multiple_borsh_attrs.snap
+++ b/borsh-derive/src/internals/attributes/field/snapshots/merge_multiple_borsh_attrs.snap
@@ -1,0 +1,5 @@
+---
+source: borsh-derive/src/internals/attributes/field/mod.rs
+expression: debug_print_tokenizable(attrs.serialize_with.as_ref())
+---
+third_party_impl :: serialize_third_party

--- a/borsh-derive/src/internals/attributes/field/snapshots/reject_duplicate_key_across_borsh_attrs.snap
+++ b/borsh-derive/src/internals/attributes/field/snapshots/reject_duplicate_key_across_borsh_attrs.snap
@@ -3,5 +3,5 @@ source: borsh-derive/src/internals/attributes/field/mod.rs
 expression: err
 ---
 Error(
-    "multiple `borsh` attributes not allowed",
+    "duplicate `serialize_with` attribute",
 )

--- a/borsh-derive/src/internals/attributes/field/snapshots/reject_duplicate_key_within_single_borsh_attr.snap
+++ b/borsh-derive/src/internals/attributes/field/snapshots/reject_duplicate_key_within_single_borsh_attr.snap
@@ -1,0 +1,7 @@
+---
+source: borsh-derive/src/internals/attributes/field/mod.rs
+expression: err
+---
+Error(
+    "duplicate `serialize_with` attribute",
+)

--- a/borsh-derive/src/internals/attributes/item/mod.rs
+++ b/borsh-derive/src/internals/attributes/item/mod.rs
@@ -2,12 +2,15 @@ use crate::internals::attributes::{BORSH, CRATE, INIT, USE_DISCRIMINANT};
 use quote::ToTokens;
 use syn::{spanned::Spanned, Attribute, DeriveInput, Error, Expr, ItemEnum, Path};
 
-use super::{get_one_attribute, parsing};
+use super::{collect_borsh_attributes, parsing};
 
 pub fn check_attributes(derive_input: &DeriveInput) -> Result<(), Error> {
-    let borsh = get_one_attribute(&derive_input.attrs)?;
+    let borsh_attrs = collect_borsh_attributes(&derive_input.attrs);
 
-    if let Some(attr) = borsh {
+    // top-level keys seen so far, shared across all `#[borsh(...)]` attributes,
+    // so a key supplied twice (within one attribute or across several) errors.
+    let mut seen_keys: Vec<&'static str> = Vec::new();
+    for attr in borsh_attrs {
         attr.parse_nested_meta(|meta| {
             if meta.path != USE_DISCRIMINANT && meta.path != INIT && meta.path != CRATE {
                 return Err(syn::Error::new(
@@ -15,6 +18,17 @@ pub fn check_attributes(derive_input: &DeriveInput) -> Result<(), Error> {
                     "`crate`, `use_discriminant` or `init` are the only supported attributes for `borsh`",
                 ));
             }
+            let key = if meta.path == USE_DISCRIMINANT {
+                USE_DISCRIMINANT.0
+            } else if meta.path == INIT {
+                INIT.0
+            } else {
+                CRATE.0
+            };
+            if seen_keys.contains(&key) {
+                return Err(meta.error(format_args!("duplicate `{}` attribute", key)));
+            }
+            seen_keys.push(key);
             if meta.path == USE_DISCRIMINANT {
                 let _expr: Expr = meta.value()?.parse()?;
                 if let syn::Data::Struct(ref _data) = derive_input.data {
@@ -43,8 +57,7 @@ pub(crate) fn contains_use_discriminant(input: &ItemEnum) -> Result<bool, syn::E
 
     let attrs = &input.attrs;
     let mut use_discriminant = None;
-    let attr = attrs.iter().find(|attr| attr.path() == BORSH);
-    if let Some(attr) = attr {
+    for attr in collect_borsh_attributes(attrs) {
         attr.parse_nested_meta(|meta| {
             if meta.path == USE_DISCRIMINANT {
                 let value_expr: Expr = meta.value()?.parse()?;
@@ -82,8 +95,7 @@ pub(crate) fn contains_use_discriminant(input: &ItemEnum) -> Result<bool, syn::E
 
 pub(crate) fn contains_initialize_with(attrs: &[Attribute]) -> Result<Option<Path>, Error> {
     let mut res = None;
-    let attr = attrs.iter().find(|attr| attr.path() == BORSH);
-    if let Some(attr) = attr {
+    for attr in collect_borsh_attributes(attrs) {
         attr.parse_nested_meta(|meta| {
             if meta.path == INIT {
                 let value_expr: Path = meta.value()?.parse()?;
@@ -101,8 +113,7 @@ pub(crate) fn contains_initialize_with(attrs: &[Attribute]) -> Result<Option<Pat
 
 pub(crate) fn get_crate(attrs: &[Attribute]) -> Result<Option<Path>, Error> {
     let mut res = None;
-    let attr = attrs.iter().find(|attr| attr.path() == BORSH);
-    if let Some(attr) = attr {
+    for attr in collect_borsh_attributes(attrs) {
         attr.parse_nested_meta(|meta| {
             if meta.path == CRATE {
                 let value_expr: Path = parsing::parse_lit_into(BORSH, CRATE, &meta)?;
@@ -248,10 +259,48 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_multiple_borsh_attrs() {
-        let item_struct = syn::parse2::<DeriveInput>(quote! {
+    fn test_merge_multiple_borsh_attrs() {
+        let item_enum = syn::parse2::<ItemEnum>(quote! {
             #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
             #[borsh(use_discriminant=true)]
+            #[borsh(init = initialization_method)]
+            enum A {
+                B,
+                C,
+                D= 10,
+            }
+        })
+        .unwrap();
+
+        let derive_input = syn::parse2::<DeriveInput>(quote! {
+            #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+            #[borsh(use_discriminant=true)]
+            #[borsh(init = initialization_method)]
+            enum A {
+                B,
+                C,
+                D= 10,
+            }
+        })
+        .unwrap();
+
+        assert!(check_attributes(&derive_input).is_ok());
+        assert!(contains_use_discriminant(&item_enum).unwrap());
+        assert_eq!(
+            contains_initialize_with(&item_enum.attrs)
+                .unwrap()
+                .unwrap()
+                .to_token_stream()
+                .to_string(),
+            "initialization_method"
+        );
+    }
+
+    #[test]
+    fn test_reject_duplicate_key_across_borsh_attrs() {
+        let item_struct = syn::parse2::<DeriveInput>(quote! {
+            #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+            #[borsh(init = initialization_method)]
             #[borsh(init = initialization_method)]
             enum A {
                 B,

--- a/borsh-derive/src/internals/attributes/item/mod.rs
+++ b/borsh-derive/src/internals/attributes/item/mod.rs
@@ -1,5 +1,6 @@
 use crate::internals::attributes::{BORSH, CRATE, INIT, USE_DISCRIMINANT};
 use quote::ToTokens;
+use std::collections::HashSet;
 use syn::{spanned::Spanned, Attribute, DeriveInput, Error, Expr, ItemEnum, Path};
 
 use super::{collect_borsh_attributes, parsing};
@@ -25,10 +26,9 @@ pub fn check_attributes(derive_input: &DeriveInput) -> Result<(), Error> {
             } else {
                 CRATE.0
             };
-            if seen_keys.contains(&key) {
+            if !seen_keys.insert(key) {
                 return Err(meta.error(format_args!("duplicate `{}` attribute", key)));
             }
-            seen_keys.push(key);
             if meta.path == USE_DISCRIMINANT {
                 let _expr: Expr = meta.value()?.parse()?;
                 if let syn::Data::Struct(ref _data) = derive_input.data {

--- a/borsh-derive/src/internals/attributes/item/mod.rs
+++ b/borsh-derive/src/internals/attributes/item/mod.rs
@@ -9,7 +9,7 @@ pub fn check_attributes(derive_input: &DeriveInput) -> Result<(), Error> {
 
     // top-level keys seen so far, shared across all `#[borsh(...)]` attributes,
     // so a key supplied twice (within one attribute or across several) errors.
-    let mut seen_keys: Vec<&'static str> = Vec::new();
+    let mut seen_keys: HashSet<&'static str> = HashSet::new();
     for attr in borsh_attrs {
         attr.parse_nested_meta(|meta| {
             if meta.path != USE_DISCRIMINANT && meta.path != INIT && meta.path != CRATE {

--- a/borsh-derive/src/internals/attributes/item/snapshots/reject_duplicate_key_across_borsh_attrs.snap
+++ b/borsh-derive/src/internals/attributes/item/snapshots/reject_duplicate_key_across_borsh_attrs.snap
@@ -3,5 +3,5 @@ source: borsh-derive/src/internals/attributes/item/mod.rs
 expression: actual.unwrap_err()
 ---
 Error(
-    "multiple `borsh` attributes not allowed",
+    "duplicate `init` attribute",
 )

--- a/borsh-derive/src/internals/attributes/mod.rs
+++ b/borsh-derive/src/internals/attributes/mod.rs
@@ -64,14 +64,11 @@ impl<'a> PartialEq<Symbol> for &'a Path {
     }
 }
 
-fn get_one_attribute(attrs: &[Attribute]) -> syn::Result<Option<&Attribute>> {
-    let count = attrs.iter().filter(|attr| attr.path() == BORSH).count();
-    let borsh = attrs.iter().find(|attr| attr.path() == BORSH);
-    if count > 1 {
-        return Err(syn::Error::new_spanned(
-            borsh.unwrap(),
-            format!("multiple `{}` attributes not allowed", BORSH.0),
-        ));
-    }
-    Ok(borsh)
+/// Collects all `#[borsh(...)]` attributes present on a field or item.
+///
+/// Multiple `#[borsh(...)]` attributes are allowed and their contents are
+/// merged by the callers. This makes it possible to split disjoint top-level
+/// keys across several attributes, e.g. behind separate `#[cfg_attr(...)]`.
+fn collect_borsh_attributes(attrs: &[Attribute]) -> Vec<&Attribute> {
+    attrs.iter().filter(|attr| attr.path() == BORSH).collect()
 }

--- a/borsh-derive/src/internals/attributes/parsing.rs
+++ b/borsh-derive/src/internals/attributes/parsing.rs
@@ -71,6 +71,9 @@ where
     let mut match_ = false;
     for (symbol_key, func) in map.iter() {
         if meta.path == *symbol_key {
+            if result.contains_key(symbol_key) {
+                return Err(meta.error(format_args!("duplicate `{}` attribute", symbol_key.0)));
+            }
             let v = func(attr_name, *symbol_key, &meta)?;
             result.insert(*symbol_key, v);
             match_ = true;
@@ -107,9 +110,15 @@ where
     Ok(result)
 }
 
-pub(super) fn attr_get_by_symbol_keys<T, F>(
+/// Parses the nested meta of every given `#[borsh(...)]` attribute, folding
+/// them into a single shared map.
+///
+/// Disjoint top-level keys spread across multiple attributes merge cleanly. A
+/// top-level key supplied more than once (whether within one attribute or
+/// across several) is reported as a duplicate by [`get_nested_meta_logic`].
+pub(super) fn attrs_get_by_symbol_keys<T, F>(
     attr_name: Symbol,
-    attr: &Attribute,
+    attrs: &[&Attribute],
     map: &BTreeMap<Symbol, F>,
 ) -> syn::Result<BTreeMap<Symbol, T>>
 where
@@ -117,7 +126,9 @@ where
 {
     let mut result = BTreeMap::new();
 
-    attr.parse_nested_meta(|meta| get_nested_meta_logic(attr_name, meta, map, &mut result))?;
+    for attr in attrs {
+        attr.parse_nested_meta(|meta| get_nested_meta_logic(attr_name, meta, map, &mut result))?;
+    }
 
     Ok(result)
 }

--- a/borsh-derive/src/internals/attributes/parsing.rs
+++ b/borsh-derive/src/internals/attributes/parsing.rs
@@ -71,6 +71,23 @@ where
     let mut match_ = false;
     for (symbol_key, func) in map.iter() {
         if meta.path == *symbol_key {
+            // This duplicate check runs at every nesting level: at the top
+            // level (via `attrs_get_by_symbol_keys` / `meta_get_by_symbol_keys`)
+            // and again for keys nested inside a group such as `schema(...)`,
+            // whose `func` recurses through `meta_get_by_symbol_keys` with its
+            // own `result`. So a key repeated at the same level is rejected here
+            // -- whether it is a top-level key spread across several
+            // `#[borsh(...)]` attributes or a nested key such as
+            // `schema(params = ...)` supplied twice.
+            //
+            // Merging is per key at a single level, not a deep merge: `schema`
+            // is itself one top-level key, so two separate `schema(...)` groups
+            // collide rather than having their inner keys combined -- inner keys
+            // must be written together inside one group.
+            //
+            // Before this check a repeated key silently kept the last `v`
+            // produced by `func` (the `insert` below overwrote the earlier one);
+            // it is now an error instead.
             if result.contains_key(symbol_key) {
                 return Err(meta.error(format_args!("duplicate `{}` attribute", symbol_key.0)));
             }

--- a/borsh/docs/rustdoc_include/borsh_deserialize.md
+++ b/borsh/docs/rustdoc_include/borsh_deserialize.md
@@ -40,6 +40,11 @@ struct A<U, V> {
 
 ## Attributes
 
+Multiple `#[borsh(...)]` attributes on the same item or field are merged: the
+top-level keys of every attribute are combined into a single set. This makes it
+possible to split disjoint keys across separate (e.g. `#[cfg_attr(...)]`-gated)
+attributes. Supplying the same top-level key more than once is an error.
+
 ### 1. `#[borsh(crate = "path::to::borsh")]` (item level attribute)
 
 ###### syntax

--- a/borsh/docs/rustdoc_include/borsh_schema.md
+++ b/borsh/docs/rustdoc_include/borsh_schema.md
@@ -35,6 +35,11 @@ struct A<U, V> {
 
 ## Attributes
 
+Multiple `#[borsh(...)]` attributes on the same item or field are merged: the
+top-level keys of every attribute are combined into a single set. This makes it
+possible to split disjoint keys across separate (e.g. `#[cfg_attr(...)]`-gated)
+attributes. Supplying the same top-level key more than once is an error.
+
 ### 1. `#[borsh(crate = "path::to::borsh")]` (item level attribute)
 
 ###### syntax

--- a/borsh/docs/rustdoc_include/borsh_serialize.md
+++ b/borsh/docs/rustdoc_include/borsh_serialize.md
@@ -37,6 +37,11 @@ struct A<U, V> {
 
 ## Attributes
 
+Multiple `#[borsh(...)]` attributes on the same item or field are merged: the
+top-level keys of every attribute are combined into a single set. This makes it
+possible to split disjoint keys across separate (e.g. `#[cfg_attr(...)]`-gated)
+attributes. Supplying the same top-level key more than once is an error.
+
 ### 1. `#[borsh(crate = "path::to::borsh")]` (item level attribute)
 
 ###### syntax

--- a/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
+++ b/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
@@ -1,0 +1,119 @@
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
+use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
+
+// the `BorshSchema` derive expands to code that uses the `format!` macro at the
+// struct definition site, so it has to be in scope here too.
+#[cfg(feature = "unstable__schema")]
+use alloc::format;
+
+#[derive(Debug, PartialEq, Eq)]
+struct ThirdParty<K, V>(pub BTreeMap<K, V>);
+
+mod third_party_impl {
+    use super::ThirdParty;
+
+    pub(super) fn serialize_third_party<
+        K: borsh::ser::BorshSerialize,
+        V: borsh::ser::BorshSerialize,
+        W: borsh::io::Write,
+    >(
+        obj: &ThirdParty<K, V>,
+        writer: &mut W,
+    ) -> ::core::result::Result<(), borsh::io::Error> {
+        borsh::BorshSerialize::serialize(&obj.0, writer)?;
+        Ok(())
+    }
+
+    pub(super) fn deserialize_third_party<
+        R: borsh::io::Read,
+        K: borsh::de::BorshDeserialize + Ord,
+        V: borsh::de::BorshDeserialize,
+    >(
+        reader: &mut R,
+    ) -> ::core::result::Result<ThirdParty<K, V>, borsh::io::Error> {
+        Ok(ThirdParty(borsh::BorshDeserialize::deserialize_reader(
+            reader,
+        )?))
+    }
+
+    #[cfg(feature = "unstable__schema")]
+    use alloc::{collections::BTreeMap, format, vec};
+
+    #[cfg(feature = "unstable__schema")]
+    pub(super) fn declaration<K: borsh::BorshSchema, V: borsh::BorshSchema>(
+    ) -> borsh::schema::Declaration {
+        let params = vec![<K>::declaration(), <V>::declaration()];
+        format!(r#"{}<{}>"#, "ThirdParty", params.join(", "))
+    }
+
+    #[cfg(feature = "unstable__schema")]
+    pub(super) fn add_definitions_recursively<K: borsh::BorshSchema, V: borsh::BorshSchema>(
+        definitions: &mut BTreeMap<borsh::schema::Declaration, borsh::schema::Definition>,
+    ) {
+        let fields = borsh::schema::Fields::UnnamedFields(vec![
+            <BTreeMap<K, V> as borsh::BorshSchema>::declaration(),
+        ]);
+        let definition = borsh::schema::Definition::Struct { fields };
+        let no_recursion_flag = definitions.get(&declaration::<K, V>()).is_none();
+        borsh::schema::add_definition(declaration::<K, V>(), definition, definitions);
+        if no_recursion_flag {
+            <BTreeMap<K, V> as borsh::BorshSchema>::add_definitions_recursively(definitions);
+        }
+    }
+}
+
+// This mirrors the `near/intents` use case: the common `serialize_with` /
+// `deserialize_with` / `bound` part is written once, and the schema-only part
+// lives in a separate, `cfg`-gated `#[borsh(...)]` attribute. borsh merges the
+// disjoint top-level keys of all `#[borsh(...)]` attributes into one.
+#[cfg_attr(feature = "unstable__schema", derive(borsh::BorshSchema))]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug)]
+struct A<K, V> {
+    #[borsh(serialize_with = "third_party_impl::serialize_third_party")]
+    #[borsh(deserialize_with = "third_party_impl::deserialize_third_party")]
+    #[borsh(bound(
+        deserialize = "K: borsh::de::BorshDeserialize + Ord, V: borsh::de::BorshDeserialize",
+    ))]
+    #[cfg_attr(
+        feature = "unstable__schema",
+        borsh(schema(with_funcs(
+            declaration = "third_party_impl::declaration::<K, V>",
+            definitions = "third_party_impl::add_definitions_recursively::<K, V>"
+        )))
+    )]
+    x: ThirdParty<K, V>,
+    y: u64,
+}
+
+#[test]
+fn test_overriden_struct_multiple_attrs() {
+    let mut m = BTreeMap::<u64, String>::new();
+    m.insert(0, "0th element".to_string());
+    m.insert(1, "1st element".to_string());
+    let th_p = ThirdParty(m);
+    let a = A { x: th_p, y: 42 };
+
+    let data = to_vec(&a).unwrap();
+
+    let actual_a = from_slice::<A<u64, String>>(&data).unwrap();
+    assert_eq!(a, actual_a);
+}
+
+#[cfg(feature = "unstable__schema")]
+#[test]
+fn test_overriden_struct_multiple_attrs_schema() {
+    use borsh::BorshSchema;
+
+    assert_eq!(
+        "A<u64, String>".to_string(),
+        <A<u64, String>>::declaration()
+    );
+    let mut defs = Default::default();
+    <A<u64, String>>::add_definitions_recursively(&mut defs);
+    // the schema-only `with_funcs` attribute from the separate `#[borsh(...)]`
+    // block takes effect: `x` resolves to the custom `ThirdParty` declaration.
+    assert!(defs.contains_key("ThirdParty<u64, String>"));
+}

--- a/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
+++ b/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
@@ -117,3 +117,37 @@ fn test_overriden_struct_multiple_attrs_schema() {
     // block takes effect: `x` resolves to the custom `ThirdParty` declaration.
     assert!(defs.contains_key("ThirdParty<u64, String>"));
 }
+
+// Item-level merge through the real derive macro: `use_discriminant` lives in
+// one `#[borsh(...)]` attribute and `init` in a separate one. Both have to take
+// effect for the assertions below to hold.
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug)]
+#[borsh(use_discriminant = true)]
+#[borsh(init = initialization_method)]
+enum WithSplitItemAttrs {
+    A,
+    B = 10,
+    C,
+}
+
+impl WithSplitItemAttrs {
+    fn initialization_method(&mut self) {
+        *self = WithSplitItemAttrs::C;
+    }
+}
+
+#[test]
+fn test_item_level_multiple_attrs() {
+    let value = WithSplitItemAttrs::B;
+    let data = to_vec(&value).unwrap();
+
+    // `use_discriminant = true` (first attribute) honors the explicit
+    // discriminant: `B = 10` serializes its tag as the byte `10`, not the
+    // positional index `1`.
+    assert_eq!(data, [10]);
+
+    // `init = initialization_method` (second attribute) runs after decoding, so
+    // the deserialized value is rewritten to `C`.
+    let decoded = from_slice::<WithSplitItemAttrs>(&data).unwrap();
+    assert_eq!(decoded, WithSplitItemAttrs::C);
+}

--- a/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
+++ b/borsh/tests/roundtrip/requires_derive_category/test_multiple_borsh_attrs.rs
@@ -89,7 +89,7 @@ struct A<K, V> {
 }
 
 #[test]
-fn test_overriden_struct_multiple_attrs() {
+fn test_overridden_struct_multiple_attrs() {
     let mut m = BTreeMap::<u64, String>::new();
     m.insert(0, "0th element".to_string());
     m.insert(1, "1st element".to_string());
@@ -104,7 +104,7 @@ fn test_overriden_struct_multiple_attrs() {
 
 #[cfg(feature = "unstable__schema")]
 #[test]
-fn test_overriden_struct_multiple_attrs_schema() {
+fn test_overridden_struct_multiple_attrs_schema() {
     use borsh::BorshSchema;
 
     assert_eq!(

--- a/borsh/tests/tests.rs
+++ b/borsh/tests/tests.rs
@@ -65,6 +65,7 @@ mod roundtrip {
         mod test_recursive_structs;
         mod test_recursive_enums;
         mod test_serde_with_third_party;
+        mod test_multiple_borsh_attrs;
         mod test_enum_discriminants;
         #[cfg(feature = "bytes")]
         mod test_ultimate_many_features_combined;


### PR DESCRIPTION
Cause: borsh rejected more than one `#[borsh(...)]` attribute on the same field or item ("multiple `borsh` attributes not allowed"). This forced duplicating shared keys (e.g. `serialize_with`/`deserialize_with`) across two `#[cfg_attr(..., borsh(...))]` blocks just to add a `cfg`-gated `schema(with_funcs(...))` for the abi build.

Fix: the top-level keys of every `#[borsh(...)]` attribute are folded into a single shared map, so disjoint keys spread across separate (e.g. `#[cfg_attr(...)]`-gated) attributes merge cleanly. Supplying the same top-level key more than once (within one attribute or across several) is reported as a `duplicate ... attribute` error. Applies to both field-level and item-level attributes.

Motivation: lets a field write the common `serialize_with`/`deserialize_with`/`bound` once and put the schema-only part in a separate `cfg`-gated `#[borsh(...)]` attribute, instead of duplicating everything.

Non-breaking: this only relaxes an existing restriction. Relaxing it was explicitly anticipated as a non-breaking follow-up when the restriction was introduced in #199 ("if needed").