### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/near/borsh-rs/compare/borsh-v1.7.0...borsh-v1.8.0) - 2026-07-16
+
+### Added
+
+- merge multiple `#[borsh(...)]` attributes instead of rejecting them ([#373](https://github.com/near/borsh-rs/pull/373))
+
 ### Changed
 
 - merge multiple `#[borsh(...)]` attributes instead of rejecting them ([#373](https://github.com/near/borsh-rs/pull/373))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ default-members = ["borsh", "borsh-derive"]
 
 [workspace.package]
 # shared version of all public crates in the workspace
-version = "1.7.0"
+version = "1.8.0"
 rust-version = "1.77.0"

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -32,7 +32,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 ascii = { version = "1.1", optional = true }
-borsh-derive = { path = "../borsh-derive", version = "~1.7.0", optional = true }
+borsh-derive = { path = "../borsh-derive", version = "~1.8.0", optional = true }
 
 # hashbrown can be used in no-std context.
 # NOTE: There is no reason to restrict use of older versions, but we don't want to get


### PR DESCRIPTION



## 🤖 New release

* `borsh-derive`: 1.7.0 -> 1.8.0
* `borsh`: 1.7.0 -> 1.8.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `borsh`

<blockquote>

## [1.8.0](https://github.com/near/borsh-rs/compare/borsh-v1.7.0...borsh-v1.8.0) - 2026-07-16

### Added

- merge multiple `#[borsh(...)]` attributes instead of rejecting them ([#373](https://github.com/near/borsh-rs/pull/373))

### Changed

- merge multiple `#[borsh(...)]` attributes instead of rejecting them ([#373](https://github.com/near/borsh-rs/pull/373))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).